### PR TITLE
Improved setting virtual reality view from reference view camera

### DIFF
--- a/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
+++ b/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
@@ -208,3 +208,36 @@ void vtkSlicerVirtualRealityLogic::SetVirtualRealityActive(bool activate)
     }
   }
 }
+
+//---------------------------------------------------------------------------
+void vtkSlicerVirtualRealityLogic::setDefaultReferenceView()
+{
+  if (!this->ActiveViewNode)
+  {
+    return;
+  }
+  if (this->ActiveViewNode->GetReferenceViewNode() != NULL)
+  {
+    // Reference view is already set, there is nothing to do
+    return;
+  }
+  if (!this->GetMRMLScene())
+  {
+    return;
+  }
+  vtkSmartPointer<vtkCollection> nodes = vtkSmartPointer<vtkCollection>::Take(
+    this->GetMRMLScene()->GetNodesByClass("vtkMRMLViewNode"));
+  vtkMRMLViewNode* viewNode = 0;
+  vtkCollectionSimpleIterator it;
+  for (nodes->InitTraversal(it); (viewNode = vtkMRMLViewNode::SafeDownCast(
+    nodes->GetNextItemAsObject(it)));)
+  {
+    if (viewNode->GetVisibility() && viewNode->IsMappedInLayout())
+    {
+      // Found a view node displayed in current layout, use this
+      break;
+    }
+  }
+  // Either use a view node displayed in current layout or just any 3D view node found in the scene
+  this->ActiveViewNode->SetAndObserveReferenceViewNode(viewNode);
+}

--- a/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.h
+++ b/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.h
@@ -61,6 +61,12 @@ public:
   /// Connects to device if not yet connected.
   void SetVirtualRealityActive(bool activate);
 
+  /// Set the first visible 3D view as reference view for
+  /// virtual reality view.
+  /// If a reference view has been already set then the
+  /// method has no effect.
+  void setDefaultReferenceView();
+
 protected:
   vtkSlicerVirtualRealityLogic();
   virtual ~vtkSlicerVirtualRealityLogic();

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -14,6 +14,7 @@ Version:   $Revision: 1.3 $
 
 // MRML includes
 #include "vtkMRMLScene.h"
+#include "vtkMRMLViewNode.h"
 #include "vtkMRMLVirtualRealityViewNode.h"
 
 // VTK includes
@@ -138,36 +139,30 @@ double* vtkMRMLVirtualRealityViewNode::defaultBackgroundColor2()
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLNode* vtkMRMLVirtualRealityViewNode::GetReferenceViewNode()
+vtkMRMLViewNode* vtkMRMLVirtualRealityViewNode::GetReferenceViewNode()
 {
-  return this->GetNodeReference(this->ReferenceViewNodeReferenceRole);
+  return vtkMRMLViewNode::SafeDownCast(this->GetNodeReference(this->ReferenceViewNodeReferenceRole));
 }
 
 //----------------------------------------------------------------------------
-bool vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNodeID(const char* viewNodeId)
+void vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNodeID(const char* viewNodeId)
 {
-  if (!viewNodeId)
-    {
-    return false;
-    }
-
   this->SetAndObserveNodeReferenceID(this->ReferenceViewNodeReferenceRole, viewNodeId);
-  return true;
 }
 
 //----------------------------------------------------------------------------
-bool vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNode(vtkMRMLNode* node)
+bool vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNode(vtkMRMLViewNode* node)
 {
-  if (node && this->Scene != node->GetScene())
+  if (node == NULL)
+    {
+    this->SetAndObserveReferenceViewNodeID(NULL);
+    return true;
+    }
+  if (this->Scene != node->GetScene() || node->GetID() == NULL)
     {
     vtkErrorMacro("SetAndObserveReferenceViewNode: The referenced and referencing node are not in the same scene");
     return false;
     }
-  if (!node->IsA("vtkMRMLViewNode"))
-    {
-    vtkErrorMacro("SetAndObserveReferenceViewNode: Wrong node type, vtkMRMLViewNode expected");
-    return false;
-    }
-
-  return this->SetAndObserveReferenceViewNodeID(node ? node->GetID() : NULL);
+   this->SetAndObserveReferenceViewNodeID(node->GetID());
+   return true;
 }

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -61,14 +61,15 @@ public:
   static double* defaultBackgroundColor2();
 
   /// Get reference view node.
-  /// VR view camera is initialized from the camera of the reference view.
-  vtkMRMLNode* GetReferenceViewNode();
-  /// Set reference view node reference
+  /// Reference view node is a regular 3D view node, which content
+  /// or view may be synchronized with the virtual reality camera view.
+  vtkMRMLViewNode* GetReferenceViewNode();
+  /// Set reference view node.
   /// \sa GetReferenceViewNode
-  bool SetAndObserveReferenceViewNodeID(const char *layoutNodeId);
-  /// Set reference view node reference
+  void SetAndObserveReferenceViewNodeID(const char *layoutNodeId);
+  /// Set reference view node.
   /// \sa GetReferenceViewNode
-  bool SetAndObserveReferenceViewNode(vtkMRMLNode* node);
+  bool SetAndObserveReferenceViewNode(vtkMRMLViewNode* node);
 
   /// Controls two-sided lighting property of the renderer
   vtkGetMacro(TwoSidedLighting, bool);

--- a/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
+++ b/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
@@ -6,58 +6,22 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>192</width>
-    <height>228</height>
+    <width>344</width>
+    <height>429</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QFormLayout" name="formLayout_2">
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="ctkCollapsibleButton" name="ConnectionCollapsibleButton">
+     <property name="minimumSize">
       <size>
-       <width>0</width>
+       <width>300</width>
        <height>0</height>
       </size>
      </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="ctkCollapsibleButton" name="DisplayCollapsibleButton">
-     <property name="text">
-      <string>Display</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Two-sided lighting:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="ctkCheckBox" name="TwoSidedLightingCheckBox"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Back-lights:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkCheckBox" name="BackLightsCheckBox"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="qMRMLCollapsibleButton" name="MRMLCollapsibleButton">
      <property name="text">
       <string>Connection</string>
      </property>
@@ -85,14 +49,87 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="DisplayCollapsibleButton">
+     <property name="text">
+      <string>Display</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Two-sided lighting:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkCheckBox" name="TwoSidedLightingCheckBox"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Back-lights:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkCheckBox" name="BackLightsCheckBox"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLNodeComboBox" name="ReferenceViewNodeComboBox">
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLViewNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Reference view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QPushButton" name="UpdateViewFromReferenceViewCameraButton">
+        <property name="text">
+         <string>Set virtual reality view to match reference view.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLCollapsibleButton</class>
-   <extends>ctkCollapsibleButton</extends>
-   <header>qMRMLCollapsibleButton.h</header>
-   <container>1</container>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
   </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>
@@ -113,5 +150,22 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>qSlicerVirtualRealityModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ReferenceViewNodeComboBox</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>134</x>
+     <y>145</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>192</x>
+     <y>216</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/VirtualReality/Widgets/CMakeLists.txt
+++ b/VirtualReality/Widgets/CMakeLists.txt
@@ -32,6 +32,7 @@ set(${KIT}_RESOURCES
 
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
+  vtkSlicerCamerasModuleLogic
   ${VTK_LIBRARIES}
   )
 

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.h
@@ -36,6 +36,7 @@ class vtkMRMLVirtualRealityViewNode;
 class vtkCollection;
 class vtkGenericOpenGLRenderWindow;
 class vtkRenderWindowInteractor;
+class vtkSlicerCamerasModuleLogic;
 
 class vtkOpenVRRenderer;
 class vtkOpenVRRenderWindow;
@@ -72,6 +73,11 @@ public:
   void addDisplayableManager(const QString& displayableManager);
   Q_INVOKABLE void getDisplayableManagers(vtkCollection *displayableManagers);
 
+  /// Set Cameras module logic.
+  /// Required for updating camera from reference view node.
+  void setCamerasLogic(vtkSlicerCamerasModuleLogic* camerasLogic);
+  vtkSlicerCamerasModuleLogic* camerasLogic()const;
+
   /// Get the 3D View node observed by view.
   Q_INVOKABLE vtkMRMLVirtualRealityViewNode* mrmlVirtualRealityViewNode()const;
 
@@ -83,6 +89,10 @@ public:
 
   /// Get underlying RenderWindow
   Q_INVOKABLE vtkOpenVRRenderWindowInteractor* interactor()const;
+
+  /// Initialize the virtual reality view to most closely
+  /// matched the camera of the reference view camera.
+  Q_INVOKABLE void updateViewFromReferenceViewCamera();
 
 public slots:
   /// Set the MRML \a scene that should be listened for events

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -83,7 +83,8 @@ public slots:
 protected:
   void createRenderWindow();
   void destroyRenderWindow();
-  void initializeViewFromReferenceView();
+
+  vtkSlicerCamerasModuleLogic* CamerasLogic;
 
   vtkSmartPointer<vtkMRMLDisplayableManagerGroup> DisplayableManagerGroup;
   vtkWeakPointer<vtkMRMLScene> MRMLScene;

--- a/VirtualReality/qSlicerVirtualRealityModule.h
+++ b/VirtualReality/qSlicerVirtualRealityModule.h
@@ -69,6 +69,7 @@ public:
 public slots:
   void setToolBarVisible(bool visible);
   void enableVirtualReality(bool);
+  void updateViewFromReferenceViewCamera();
 
 protected slots:
   void onViewNodeModified();

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.h
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.h
@@ -41,6 +41,8 @@ public slots:
   void setVirtualRealityActive(bool activate);
   void setTwoSidedLighting(bool);
   void setBackLights(bool);
+  void setReferenceViewNode(vtkMRMLNode*);
+  void updateViewFromReferenceViewCamera();
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
- Separated setReferenceViewNode(vtkMRMLNode*) and updateViewpointFromReferenceView() methods from each other and made them available on the GUI.
- Added updating of view from reference view to the toolbar.
- Use Cameras module to get camera from view node (instead of going through the layout manager), this allowed setDefaultReferenceView() to be implemented in module logic.
- Improved updateViewFromReferenceViewCamera implementation: the method in RenderWindow->InitializeViewFromCamera(cam) has two major issues: it puts the headset in the focal point (so we need to step back to see the full content) and it snaps view direction to the closest axis (so it does not reproduce the reference view orientation accurately).