### PR TITLE
Adding population of controller transforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(SlicerVirtualReality)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerVirtualReality")
 set(EXTENSION_CATEGORY "Virtual Reality")
-set(EXTENSION_CONTRIBUTORS "Jean-Baptiste Vimort (Kitware), Jean-Christophe Fillion-Robin (Kitware), Csaba Pinter (PerkLab, Queen's University)")
+set(EXTENSION_CONTRIBUTORS "Jean-Baptiste Vimort (Kitware), Jean-Christophe Fillion-Robin (Kitware), Csaba Pinter (PerkLab, Queen's University), Adam Rankin (VASST Lab, Robarts Research Institute, Western University)")
 set(EXTENSION_DESCRIPTION "Allows user to interact with a Slicer scene using virtual reality.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/KitwareMedical/SlicerVirtualReality/master/SlicerVirtualReality.png")
 set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/w/images/4/49/SlicerVirtualReality_Screenshot1.png https://www.slicer.org/w/images/0/04/SlicerVirtualReality_Screenshot2.png")

--- a/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
+++ b/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
@@ -16,11 +16,13 @@
 ==============================================================================*/
 
 // VirtualReality Logic includes
-#include "vtkSlicerVirtualRealityLogic.h"
 #include "vtkMRMLVirtualRealityViewNode.h"
+#include "vtkSlicerVirtualRealityLogic.h"
 
 // MRML includes
+#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLScene.h>
+
 // VTK includes
 #include <vtkIntArray.h>
 #include <vtkNew.h>
@@ -151,6 +153,36 @@ void vtkSlicerVirtualRealityLogic::SetActiveViewNode(vtkMRMLVirtualRealityViewNo
   }
 
   this->GetMRMLNodesObserverManager()->SetAndObserveObject(vtkObjectPointer(&this->ActiveViewNode), vrViewNode);
+
+  if (this->ActiveViewNode == NULL)
+  {
+    this->Modified();
+    return;
+  }
+
+  // We create or get and update the linear transform nodes that correspond to left and right controllers
+  vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(this->GetMRMLScene()->GetSingletonNode("VirtualReality.LeftController", "vtkMRMLLinearTransformNode"));
+  if (linearTransformNode == NULL)
+  {
+    linearTransformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::Take(
+      vtkMRMLLinearTransformNode::SafeDownCast(this->GetMRMLScene()->CreateNodeByClass("vtkMRMLLinearTransformNode")));
+    linearTransformNode->SetSingletonTag("VirtualReality.LeftController");
+    linearTransformNode->SetName("VirtualReality.LeftController");
+    this->GetMRMLScene()->AddNode(linearTransformNode);
+  }
+  this->ActiveViewNode->SetAndObserveLeftControllerTransformNode(linearTransformNode);
+
+  // Right
+  linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(this->GetMRMLScene()->GetSingletonNode("VirtualReality.RightController", "vtkMRMLLinearTransformNode"));
+  if (linearTransformNode == NULL)
+  {
+    linearTransformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::Take(
+      vtkMRMLLinearTransformNode::SafeDownCast(this->GetMRMLScene()->CreateNodeByClass("vtkMRMLLinearTransformNode")));
+    linearTransformNode->SetSingletonTag("VirtualReality.RightController");
+    linearTransformNode->SetName("VirtualReality.RightController");
+    this->GetMRMLScene()->AddNode(linearTransformNode);
+  }
+  this->ActiveViewNode->SetAndObserveRightControllerTransformNode(linearTransformNode);
 
   this->Modified();
 }

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -24,6 +24,8 @@ Version:   $Revision: 1.3 $
 #include <sstream>
 
 const char* vtkMRMLVirtualRealityViewNode::ReferenceViewNodeReferenceRole = "ReferenceViewNodeRef";
+const char* vtkMRMLVirtualRealityViewNode::LeftControllerTransformRole = "LeftController";
+const char* vtkMRMLVirtualRealityViewNode::RightControllerTransformRole = "RightController";
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLVirtualRealityViewNode);
@@ -151,13 +153,13 @@ double* vtkMRMLVirtualRealityViewNode::defaultBackgroundColor2()
 //----------------------------------------------------------------------------
 vtkMRMLViewNode* vtkMRMLVirtualRealityViewNode::GetReferenceViewNode()
 {
-  return vtkMRMLViewNode::SafeDownCast(this->GetNodeReference(this->ReferenceViewNodeReferenceRole));
+  return vtkMRMLViewNode::SafeDownCast(this->GetNodeReference(vtkMRMLVirtualRealityViewNode::ReferenceViewNodeReferenceRole));
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNodeID(const char* viewNodeId)
 {
-  this->SetAndObserveNodeReferenceID(this->ReferenceViewNodeReferenceRole, viewNodeId);
+  this->SetAndObserveNodeReferenceID(vtkMRMLVirtualRealityViewNode::ReferenceViewNodeReferenceRole, viewNodeId);
 }
 
 //----------------------------------------------------------------------------
@@ -175,4 +177,79 @@ bool vtkMRMLVirtualRealityViewNode::SetAndObserveReferenceViewNode(vtkMRMLViewNo
     }
    this->SetAndObserveReferenceViewNodeID(node->GetID());
    return true;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetControllerTransformNode(vtkEventDataDevice device)
+{
+  if (device == vtkEventDataDevice::LeftController)
+  {
+    return this->GetLeftControllerTransformNode();
+  }
+  else if(device == vtkEventDataDevice::RightController)
+  {
+    return this->GetRightControllerTransformNode();
+  }
+  else
+  {
+    return NULL;
+  }
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetLeftControllerTransformNode()
+{
+  return vtkMRMLLinearTransformNode::SafeDownCast(this->GetNodeReference(vtkMRMLVirtualRealityViewNode::LeftControllerTransformRole));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVirtualRealityViewNode::SetAndObserveLeftControllerTransformNodeID(const char *nodeId)
+{
+  this->SetAndObserveNodeReferenceID(vtkMRMLVirtualRealityViewNode::LeftControllerTransformRole, nodeId);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLVirtualRealityViewNode::SetAndObserveLeftControllerTransformNode(vtkMRMLLinearTransformNode* node)
+{
+  if (node == NULL)
+  {
+    this->SetAndObserveLeftControllerTransformNodeID(NULL);
+    return true;
+  }
+  if (this->Scene != node->GetScene() || node->GetID() == NULL)
+  {
+    vtkErrorMacro("SetAndObserveLeftControllerTransformNode: The referenced and referencing node are not in the same scene");
+    return false;
+  }
+  this->SetAndObserveLeftControllerTransformNodeID(node->GetID());
+  return true;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetRightControllerTransformNode()
+{
+  return vtkMRMLLinearTransformNode::SafeDownCast(this->GetNodeReference(vtkMRMLVirtualRealityViewNode::RightControllerTransformRole));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVirtualRealityViewNode::SetAndObserveRightControllerTransformNodeID(const char *nodeId)
+{
+  this->SetAndObserveNodeReferenceID(vtkMRMLVirtualRealityViewNode::RightControllerTransformRole, nodeId);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLVirtualRealityViewNode::SetAndObserveRightControllerTransformNode(vtkMRMLLinearTransformNode* node)
+{
+  if (node == NULL)
+  {
+    this->SetAndObserveRightControllerTransformNodeID(NULL);
+    return true;
+  }
+  if (this->Scene != node->GetScene() || node->GetID() == NULL)
+  {
+    vtkErrorMacro("SetAndObserveRightControllerTransformNode: The referenced and referencing node are not in the same scene");
+    return false;
+  }
+  this->SetAndObserveRightControllerTransformNodeID(node->GetID());
+  return true;
 }

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -15,8 +15,12 @@
 #ifndef __vtkMRMLVirtualRealityViewNode_h
 #define __vtkMRMLVirtualRealityViewNode_h
 
+// MRML includes
+#include <vtkMRMLViewNode.h>
+#include <vtkMRMLLinearTransformNode.h>
+
 // VTK includes
-#include "vtkMRMLViewNode.h"
+#include <vtkEventData.h>
 
 #include "vtkSlicerVirtualRealityModuleMRMLExport.h"
 
@@ -71,6 +75,29 @@ public:
   /// \sa GetReferenceViewNode
   bool SetAndObserveReferenceViewNode(vtkMRMLViewNode* node);
 
+  /// Get controller node by device identifier
+  vtkMRMLLinearTransformNode* GetControllerTransformNode(vtkEventDataDevice device);
+
+  /// Get left controller transform node.
+  /// Left controller transform node contains the 3D pose of the left controller
+  vtkMRMLLinearTransformNode* GetLeftControllerTransformNode();
+  /// Set left controller transform node.
+  /// \sa GetLeftControllerTransformNode
+  void SetAndObserveLeftControllerTransformNodeID(const char *nodeId);
+  /// Set left controller transform node.
+  /// \sa GetLeftControllerTransformNode
+  bool SetAndObserveLeftControllerTransformNode(vtkMRMLLinearTransformNode* node);
+
+  /// Get right controller transform node.
+  /// Right controller transform node contains the 3D pose of the right controller
+  vtkMRMLLinearTransformNode* GetRightControllerTransformNode();
+  /// Set right controller transform node.
+  /// \sa GetRightControllerTransformNode
+  void SetAndObserveRightControllerTransformNodeID(const char *nodeId);
+  /// Set right controller transform node.
+  /// \sa GetRightControllerTransformNode
+  bool SetAndObserveRightControllerTransformNode(vtkMRMLLinearTransformNode* node);
+
   /// Controls two-sided lighting property of the renderer
   vtkGetMacro(TwoSidedLighting, bool);
   vtkSetMacro(TwoSidedLighting, bool);
@@ -105,6 +132,8 @@ protected:
   void operator=(const vtkMRMLVirtualRealityViewNode&);
 
   static const char* ReferenceViewNodeReferenceRole;
+  static const char* LeftControllerTransformRole;
+  static const char* RightControllerTransformRole;
 };
 
 #endif

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -19,10 +19,11 @@
 ==============================================================================*/
 
 // Need to be included before qMRMLVRView_p
-#include <vtkOpenVRRenderer.h>
+#include <vtkOpenVRCamera.h>
+#include <vtkOpenVRInteractorStyle.h>
 #include <vtkOpenVRRenderWindow.h>
 #include <vtkOpenVRRenderWindowInteractor.h>
-#include <vtkOpenVRCamera.h>
+#include <vtkOpenVRRenderer.h>
 
 #include "qMRMLVirtualRealityView_p.h"
 
@@ -59,6 +60,7 @@
 #include <vtkThreeDViewInteractorStyle.h>
 
 // MRML includes
+#include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLVirtualRealityViewNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLCameraNode.h>
@@ -71,14 +73,12 @@
 #include <vtkNew.h>
 #include <vtkOpenGLFramebufferObject.h>
 #include <vtkPolyDataMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkRendererCollection.h>
 #include <vtkSmartPointer.h>
-#include <vtkRenderWindow.h>
-#include <vtkRenderWindowInteractor.h>
 #include <vtkTimerLog.h>
-
-#include "qSlicerApplication.h"
 
 //--------------------------------------------------------------------------
 // qMRMLVirtualRealityViewPrivate methods
@@ -137,6 +137,9 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow()
   this->RenderWindow = vtkSmartPointer<vtkOpenVRRenderWindow>::New();
   this->Renderer = vtkSmartPointer<vtkOpenVRRenderer>::New();
   this->Interactor = vtkSmartPointer<vtkOpenVRRenderWindowInteractor>::New();
+  this->InteractorStyle = vtkSmartPointer<vtkOpenVRInteractorStyle>::New();
+  this->Interactor->SetInteractorStyle(this->InteractorStyle);
+  this->InteractorStyle->SetInteractor(this->Interactor);
   this->Camera = vtkSmartPointer<vtkOpenVRCamera>::New();
   this->Renderer->SetActiveCamera(this->Camera);
 
@@ -149,29 +152,29 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow()
 
   QStringList displayableManagers;
   displayableManagers //<< "vtkMRMLCameraDisplayableManager"
-                      //<< "vtkMRMLViewDisplayableManager"
-                      << "vtkMRMLModelDisplayableManager"
-                      << "vtkMRMLThreeDReformatDisplayableManager"
-                      << "vtkMRMLCrosshairDisplayableManager3D"
-                      //<< "vtkMRMLOrientationMarkerDisplayableManager" // Not supported in VR
-                      //<< "vtkMRMLRulerDisplayableManager" // Not supported in VR
-                      << "vtkMRMLAnnotationDisplayableManager"
-                      << "vtkMRMLMarkupsFiducialDisplayableManager3D"
-                      << "vtkMRMLSegmentationsDisplayableManager3D"
-                      << "vtkMRMLTransformsDisplayableManager3D"
-                      << "vtkMRMLLinearTransformsDisplayableManager3D"
-                      << "vtkMRMLVolumeRenderingDisplayableManager"
-                      ;
-  foreach(const QString& displayableManager, displayableManagers)
+  //<< "vtkMRMLViewDisplayableManager"
+      << "vtkMRMLModelDisplayableManager"
+      << "vtkMRMLThreeDReformatDisplayableManager"
+      << "vtkMRMLCrosshairDisplayableManager3D"
+      //<< "vtkMRMLOrientationMarkerDisplayableManager" // Not supported in VR
+      //<< "vtkMRMLRulerDisplayableManager" // Not supported in VR
+      << "vtkMRMLAnnotationDisplayableManager"
+      << "vtkMRMLMarkupsFiducialDisplayableManager3D"
+      << "vtkMRMLSegmentationsDisplayableManager3D"
+      << "vtkMRMLTransformsDisplayableManager3D"
+      << "vtkMRMLLinearTransformsDisplayableManager3D"
+      << "vtkMRMLVolumeRenderingDisplayableManager"
+      ;
+  foreach (const QString& displayableManager, displayableManagers)
+  {
+    if (!factory->IsDisplayableManagerRegistered(displayableManager.toLatin1()))
     {
-    if(!factory->IsDisplayableManagerRegistered(displayableManager.toLatin1()))
-      {
       factory->RegisterDisplayableManager(displayableManager.toLatin1());
-      }
     }
+  }
 
   this->DisplayableManagerGroup = vtkSmartPointer<vtkMRMLDisplayableManagerGroup>::Take(
-    factory->InstantiateDisplayableManagers(q->renderer()));
+                                    factory->InstantiateDisplayableManagers(q->renderer()));
   this->DisplayableManagerGroup->SetMRMLDisplayableNode(this->MRMLVirtualRealityViewNode);
 
   qDebug() << "this->DisplayableManagerGroup" << this->DisplayableManagerGroup->GetDisplayableManagerCount();
@@ -216,12 +219,14 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow()
 
   q->updateViewFromReferenceViewCamera();
 
+  this->InteractorStyle->ToggleDrawControls();
+
   this->RenderWindow->Initialize();
   if (!this->RenderWindow->GetHMD())
-    {
+  {
     qWarning() << "Failed to initialize OpenVR RenderWindow";
     return;
-    }
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -231,6 +236,7 @@ void qMRMLVirtualRealityViewPrivate::destroyRenderWindow()
   this->VirtualRealityLoopTimer.stop();
   this->RenderWindow = NULL;
   this->Interactor = NULL;
+  this->InteractorStyle = NULL;
   this->DisplayableManagerGroup = NULL;
   this->Renderer = NULL;
   this->Camera = NULL;
@@ -272,15 +278,15 @@ void qMRMLVirtualRealityView::updateViewFromReferenceViewCamera()
   // but that is not usable for us, as it puts the headset in the focal point (so we
   // need to step back to see the full content) and snaps view direction to the closest axis.
 
-  vtkCamera *sourceCamera = cameraNode->GetCamera();
+  vtkCamera* sourceCamera = cameraNode->GetCamera();
 
-  vtkRenderer *ren = static_cast<vtkRenderer *>(d->RenderWindow->GetRenderers()->GetItemAsObject(0));
+  vtkRenderer* ren = static_cast<vtkRenderer*>(d->RenderWindow->GetRenderers()->GetItemAsObject(0));
   if (!ren)
   {
     qWarning() << Q_FUNC_INFO << "The renderer must be set prior to calling InitializeViewFromCamera";
     return;
   }
-  vtkOpenVRCamera *cam = vtkOpenVRCamera::SafeDownCast(ren->GetActiveCamera());
+  vtkOpenVRCamera* cam = vtkOpenVRCamera::SafeDownCast(ren->GetActiveCamera());
   if (!cam)
   {
     qWarning() << Q_FUNC_INFO << "The renderer's active camera must be set prior to calling InitializeViewFromCamera";
@@ -307,7 +313,7 @@ void qMRMLVirtualRealityView::updateViewFromReferenceViewCamera()
 
   double* sourceDirectionOfProjection = sourceCamera->GetDirectionOfProjection();
   d->RenderWindow->SetPhysicalViewDirection(sourceDirectionOfProjection);
-  double *idop = d->RenderWindow->GetPhysicalViewDirection();
+  double* idop = d->RenderWindow->GetPhysicalViewDirection();
   cam->SetPosition(
     -idop[0] * distance + sourcePosition[0],
     -idop[1] * distance + sourcePosition[1],
@@ -321,9 +327,9 @@ void qMRMLVirtualRealityViewPrivate::setMRMLScene(vtkMRMLScene* newScene)
 {
   Q_Q(qMRMLVirtualRealityView);
   if (newScene == this->MRMLScene)
-    {
+  {
     return;
-    }
+  }
   this->MRMLScene = newScene;
 }
 
@@ -332,7 +338,7 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRML()
 {
   Q_Q(qMRMLVirtualRealityView);
   if (!this->MRMLVirtualRealityViewNode
-    || !this->MRMLVirtualRealityViewNode->GetVisibility())
+      || !this->MRMLVirtualRealityViewNode->GetVisibility())
   {
     if (this->RenderWindow != NULL)
     {
@@ -428,23 +434,23 @@ void qMRMLVirtualRealityViewPrivate::doOpenVirtualReality()
         // sensitivity = 0    -> limit = 10.0x
         // sensitivity = 50%  -> limit =  1.0x
         // sensitivity = 100% -> limit =  0.1x
-        double limitScale = pow(100, 0.5-this->MRMLVirtualRealityViewNode->GetMotionSensitivity());
+        double limitScale = pow(100, 0.5 - this->MRMLVirtualRealityViewNode->GetMotionSensitivity());
 
         const double angularSpeedLimitRadiansPerSec = vtkMath::RadiansFromDegrees(5.0 * limitScale);
         double viewDirectionChangeSpeed = vtkMath::AngleBetweenVectors(this->LastViewDirection,
-          this->Camera->GetViewPlaneNormal()) / this->LastViewUpdateTime->GetElapsedTime();
+                                          this->Camera->GetViewPlaneNormal()) / this->LastViewUpdateTime->GetElapsedTime();
         double viewUpDirectionChangeSpeed = vtkMath::AngleBetweenVectors(this->LastViewUp,
-          this->Camera->GetViewUp()) / this->LastViewUpdateTime->GetElapsedTime();
+                                            this->Camera->GetViewUp()) / this->LastViewUpdateTime->GetElapsedTime();
 
         const double translationSpeedLimitMmPerSec = 100.0 * limitScale;
         // Physical scale = 100 if virtual objects are real-world size; <100 if virtual objects are larger
         double viewTranslationSpeedMmPerSec = this->RenderWindow->GetPhysicalScale() * 0.01 *
-          sqrt(vtkMath::Distance2BetweenPoints(this->LastViewPosition, this->Camera->GetPosition()))
-          / this->LastViewUpdateTime->GetElapsedTime();
+                                              sqrt(vtkMath::Distance2BetweenPoints(this->LastViewPosition, this->Camera->GetPosition()))
+                                              / this->LastViewUpdateTime->GetElapsedTime();
 
         if (viewDirectionChangeSpeed < angularSpeedLimitRadiansPerSec
-          && viewUpDirectionChangeSpeed < angularSpeedLimitRadiansPerSec
-          && viewTranslationSpeedMmPerSec  < translationSpeedLimitMmPerSec)
+            && viewUpDirectionChangeSpeed < angularSpeedLimitRadiansPerSec
+            && viewTranslationSpeedMmPerSec  < translationSpeedLimitMmPerSec)
         {
           quickViewMotion = false;
         }
@@ -456,9 +462,65 @@ void qMRMLVirtualRealityViewPrivate::doOpenVirtualReality()
       this->Camera->GetViewPlaneNormal(this->LastViewDirection);
       this->Camera->GetViewUp(this->LastViewUp);
       this->Camera->GetPosition(this->LastViewPosition);
+
+      int disabledModify = this->MRMLVirtualRealityViewNode->StartModify();
+      updateTransformNodeWithControllerPose(vtkEventDataDevice::LeftController);
+      updateTransformNodeWithControllerPose(vtkEventDataDevice::RightController);
+      this->MRMLVirtualRealityViewNode->EndModify(disabledModify);
+
       this->LastViewUpdateTime->StartTimer();
     }
+  }
+}
 
+// --------------------------------------------------------------------------
+void qMRMLVirtualRealityViewPrivate::updateTransformNodeWithControllerPose(vtkEventDataDevice device)
+{
+  vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->GetControllerTransformNode(device);
+
+  if (node == NULL)
+  {
+    qCritical() << "Unable to retrieve linear transform node for device: " << (int)device;
+    return;
+  }
+
+  if (this->RenderWindow->GetTrackedDeviceIndexForDevice(device) == vr::k_unTrackedDeviceIndexInvalid)
+  {
+    node->SetAttribute("VirtualReality.ControllerActive", "0");
+    node->SetAttribute("VirtualReality.ControllerConnected", "0");
+    return;
+  }
+
+  vr::TrackedDevicePose_t& pose = this->RenderWindow->GetTrackedDevicePose(this->RenderWindow->GetTrackedDeviceIndexForDevice(device));
+  if (pose.eTrackingResult != vr::TrackingResult_Running_OK)
+  {
+    node->SetAttribute("VirtualReality.ControllerActive", "0");
+  }
+  else
+  {
+    node->SetAttribute("VirtualReality.ControllerActive", "1");
+  }
+
+  if (!pose.bDeviceIsConnected)
+  {
+    node->SetAttribute("VirtualReality.ControllerConnected", "0");
+  }
+  else
+  {
+    node->SetAttribute("VirtualReality.ControllerConnected", "1");
+  }
+
+  double pos[3];
+  double ppos[3];
+  double wxyz[4];
+  double wdir[3];
+  this->Interactor->ConvertPoseToWorldCoordinates(pose, pos, wxyz, ppos, wdir);
+  vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
+  transform->Translate(pos);
+  transform->RotateWXYZ(wxyz[0], wxyz[1], wxyz[2], wxyz[3]);
+  if (node != nullptr)
+  {
+    node->SetMatrixTransformToParent(transform->GetMatrix());
   }
 }
 
@@ -496,9 +558,9 @@ void qMRMLVirtualRealityView::setMRMLScene(vtkMRMLScene* newScene)
   d->setMRMLScene(newScene);
 
   if (d->MRMLVirtualRealityViewNode && newScene != d->MRMLVirtualRealityViewNode->GetScene())
-    {
+  {
     this->setMRMLVirtualRealityViewNode(0);
-    }
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -506,9 +568,9 @@ void qMRMLVirtualRealityView::setMRMLVirtualRealityViewNode(vtkMRMLVirtualRealit
 {
   Q_D(qMRMLVirtualRealityView);
   if (d->MRMLVirtualRealityViewNode == newViewNode)
-    {
+  {
     return;
-    }
+  }
 
   d->qvtkReconnect(
     d->MRMLVirtualRealityViewNode, newViewNode,
@@ -530,17 +592,17 @@ vtkMRMLVirtualRealityViewNode* qMRMLVirtualRealityView::mrmlVirtualRealityViewNo
 }
 
 //------------------------------------------------------------------------------
-void qMRMLVirtualRealityView::getDisplayableManagers(vtkCollection *displayableManagers)
+void qMRMLVirtualRealityView::getDisplayableManagers(vtkCollection* displayableManagers)
 {
   Q_D(qMRMLVirtualRealityView);
 
   if (!displayableManagers || !d->DisplayableManagerGroup)
-    {
+  {
     return;
-    }
+  }
   int num = d->DisplayableManagerGroup->GetDisplayableManagerCount();
   for (int n = 0; n < num; n++)
-    {
+  {
     displayableManagers->AddItem(d->DisplayableManagerGroup->GetNthDisplayableManager(n));
-    }
+  }
 }

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -34,6 +34,7 @@
 
 // VTK includes
 //#include <vtkOpenGLFramebufferObject.h>
+#include <vtkEventData.h>
 #include <vtkWeakPointer.h>
 
 // CTK includes
@@ -48,10 +49,11 @@
 
 class QLabel;
 class vtkLightCollection;
+class vtkMRMLCameraNode;
 class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLVirtualRealityViewNode;
-class vtkMRMLCameraNode;
 class vtkObject;
+class vtkOpenVRInteractorStyle;
 class vtkTimerLog;
 
 //-----------------------------------------------------------------------------
@@ -80,6 +82,7 @@ public slots:
   void doOpenVirtualReality();
 
 protected:
+  void updateTransformNodeWithControllerPose(vtkEventDataDevice device);
   void createRenderWindow();
   void destroyRenderWindow();
 
@@ -91,6 +94,7 @@ protected:
   vtkSmartPointer<vtkOpenVRRenderer> Renderer;
   vtkSmartPointer<vtkOpenVRRenderWindow> RenderWindow;
   vtkSmartPointer<vtkOpenVRRenderWindowInteractor> Interactor;
+  vtkSmartPointer<vtkOpenVRInteractorStyle> InteractorStyle;
   vtkSmartPointer<vtkOpenVRCamera> Camera;
   vtkSmartPointer<vtkLightCollection> Lights;
 


### PR DESCRIPTION
Controller transforms are created (or re-referenced if already existing) when a valid VR view node is set.

At present nodes are never destroyed.