### PR TITLE
Adding UI and back-end control to enable toggling of TrackHMD

### DIFF
--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -40,6 +40,7 @@ vtkMRMLVirtualRealityViewNode::vtkMRMLVirtualRealityViewNode()
   , MotionSpeed(1.6666)
   , ControllerTransformsUpdate(false)
   , ControllerModelsVisible(true)
+  , TrackHMD(true)
 {
   this->Visibility = 0; // hidden by default to not connect to the headset until it is needed
   this->BackgroundColor[0] = this->defaultBackgroundColor()[0];
@@ -75,6 +76,7 @@ void vtkMRMLVirtualRealityViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(motionSensitivity, MotionSensitivity);
   vtkMRMLWriteXMLBooleanMacro(controllerTransformsUpdate, ControllerTransformsUpdate);
   vtkMRMLWriteXMLBooleanMacro(controllerModelsVisible, ControllerModelsVisible);
+  vtkMRMLWriteXMLBooleanMacro(trackHMD, TrackHMD);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -94,6 +96,7 @@ void vtkMRMLVirtualRealityViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(motionSensitivity, MotionSensitivity);
   vtkMRMLReadXMLBooleanMacro(controllerTransformsUpdate, ControllerTransformsUpdate);
   vtkMRMLReadXMLBooleanMacro(controllerModelsVisible, ControllerModelsVisible);
+  vtkMRMLReadXMLBooleanMacro(trackHMD, TrackHMD);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -117,6 +120,7 @@ void vtkMRMLVirtualRealityViewNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyFloatMacro(MotionSensitivity);
   vtkMRMLCopyBooleanMacro(ControllerTransformsUpdate);
   vtkMRMLCopyBooleanMacro(ControllerModelsVisible);
+  vtkMRMLCopyBooleanMacro(TrackHMD);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -136,6 +140,7 @@ void vtkMRMLVirtualRealityViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(MotionSensitivity);
   vtkMRMLPrintBooleanMacro(ControllerTransformsUpdate);
   vtkMRMLPrintBooleanMacro(ControllerModelsVisible);
+  vtkMRMLPrintBooleanMacro(TrackHMD);
   vtkMRMLPrintEndMacro();
 }
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -143,6 +143,11 @@ public:
   vtkSetMacro(ControllerModelsVisible, bool);
   vtkBooleanMacro(ControllerModelsVisible, bool);
 
+  /// If set to true then VTK camera is updated with headset's physical location
+  vtkGetMacro(TrackHMD, bool);
+  vtkSetMacro(TrackHMD, bool);
+  vtkBooleanMacro(TrackHMD, bool);
+
   /// Return true if an error has occurred.
   /// "Connected" member requests connection but this method can tell if the
   /// hardware connection has been actually successfully established.
@@ -166,6 +171,7 @@ protected:
   double MotionSensitivity;
   bool ControllerTransformsUpdate;
   bool ControllerModelsVisible;
+  bool TrackHMD;
 
   std::string LastErrorMessage;
 

--- a/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
+++ b/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
@@ -129,14 +129,38 @@
       <item row="1" column="1">
        <widget class="ctkCheckBox" name="BackLightsCheckBox"/>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="ControllerModelsVisibleLabel">
+        <property name="text">
+         <string>Controllers visible:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkCheckBox" name="ControllerModelsVisibleCheckBox">
+        <property name="toolTip">
+         <string>If checked, then controllers are displayed in virtual reality view.</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0">
+       <widget class="QLabel" name="TrackHMDLabel">
+        <property name="text">
+         <string>Track HMD:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Update rate:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="ctkSliderWidget" name="DesiredUpdateRateSlider">
         <property name="toolTip">
          <string>Desired update rate of the view. Higher value reduces time lag but may decrease display quality of volume rendering. It has only effect if volume rendering quality setting is Adaptive.</string>
@@ -155,24 +179,17 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QPushButton" name="UpdateViewFromReferenceViewCameraButton">
         <property name="text">
          <string>Set virtual reality view to match reference view.</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="ControllerModelsVisibleLabel">
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="TrackHMDCheckBox">
         <property name="text">
-         <string>Controllers visible:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkCheckBox" name="ControllerModelsVisibleCheckBox">
-        <property name="toolTip">
-         <string>If checked, then controllers are displayed in virtual reality view.</string>
+         <string/>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -353,6 +353,8 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRML()
   {
     this->VirtualRealityLoopTimer.stop();
   }
+
+  this->RenderWindow->SetTrackHMD(this->MRMLVirtualRealityViewNode->GetTrackHMD());
 }
 
 //---------------------------------------------------------------------------

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.cxx
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.cxx
@@ -86,6 +86,7 @@ void qSlicerVirtualRealityModuleWidget::setup()
   connect(d->MagnificationSlider, SIGNAL(valueChanged(double)), this, SLOT(onMagnificationChanged(double)));
   connect(d->MotionSpeedSlider, SIGNAL(valueChanged(double)), this, SLOT(onMotionSpeedChanged(double)));
   connect(d->ControllerTransformsUpdateCheckBox, SIGNAL(toggled(bool)), this, SLOT(setControllerTransformsUpdate(bool)));
+  connect(d->TrackHMDCheckBox, SIGNAL(toggled(bool)), this, SLOT(setTrackHMD(bool)));
 
   // Make magnification label same width as motion sensitivity spinbox
   ctkDoubleSpinBox* motionSpeedSpinBox = d->MotionSpeedSlider->findChild<ctkDoubleSpinBox*>("SpinBox");
@@ -166,6 +167,11 @@ void qSlicerVirtualRealityModuleWidget::updateWidgetFromMRML()
   d->ControllerTransformsUpdateCheckBox->setEnabled(vrViewNode != NULL);
   d->ControllerTransformsUpdateCheckBox->blockSignals(wasBlocked);
 
+  wasBlocked = d->TrackHMDCheckBox->blockSignals(true);
+  d->TrackHMDCheckBox->setChecked(vrViewNode != NULL && vrViewNode->GetTrackHMD());
+  d->TrackHMDCheckBox->setEnabled(vrViewNode != NULL);
+  d->TrackHMDCheckBox->blockSignals(wasBlocked);
+
   d->UpdateViewFromReferenceViewCameraButton->setEnabled(vrViewNode != NULL
     && vrViewNode->GetReferenceViewNode() != NULL);
 }
@@ -219,6 +225,18 @@ void qSlicerVirtualRealityModuleWidget::setControllerModelsVisible(bool visible)
   if (vrViewNode)
   {
     vrViewNode->SetControllerModelsVisible(visible);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::setTrackHMD(bool track)
+{
+  Q_D(qSlicerVirtualRealityModuleWidget);
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetTrackHMD(track);
   }
 }
 

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.h
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.h
@@ -42,6 +42,7 @@ public slots:
   void setTwoSidedLighting(bool);
   void setBackLights(bool);
   void setControllerModelsVisible(bool);
+  void setTrackHMD(bool);
   void setReferenceViewNode(vtkMRMLNode*);
   void updateViewFromReferenceViewCamera();
   void onDesiredUpdateRateChanged(double);


### PR DESCRIPTION
Working towards driving the vtkOpenVRCamera from a slicer camera or transform node, first must be able to disable the camera being driven by the headset physical tracking