### PR TITLE
ENH: Make trigger button configurable

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
@@ -36,7 +36,21 @@ public:
   vtkTypeMacro(vtkVirtualRealityViewInteractor,vtkOpenVRRenderWindowInteractor);
   void PrintSelf(ostream& os, vtkIndent indent);
 
+  virtual void SetInteractorStyle(vtkInteractorObserver*);
+
   virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata) override;
+
+  /// Set trigger button function
+  /// By default it is the same as grab (\sa GetButtonFunctionIdForGrabObjectsAndWorld)
+  /// Empty string disables button
+  void SetTriggerButtonFunction(std::string functionId);
+
+  /// Get string constant corresponding to button function "grab objects and world"
+  static std::string GetButtonFunctionIdForGrabObjectsAndWorld() { return "GrabObjectsAndWorld"; };
+
+protected:
+  /// List of buttons for which gesture recognition is enabled
+  std::vector<int> GestureEnabledButtons;
 
 private:
   vtkVirtualRealityViewInteractor();

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
@@ -68,7 +68,7 @@ public:
     vtkMatrix4x4* controller0Pose, vtkMatrix4x4* controller1Pose, vtkMatrix4x4* combinedPose);
 
 public:
-  // Store required controllers information when performing action
+  /// Store required controllers information when performing action
   int InteractionState[vtkEventDataNumberOfDevices];
 
   vtkWeakPointer<vtkMRMLDisplayableNode> PickedNode[vtkEventDataNumberOfDevices];

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
@@ -46,24 +46,17 @@ public:
   vtkTypeMacro(vtkVirtualRealityViewInteractorStyle,vtkInteractorStyle3D);
   void PrintSelf(ostream& os, vtkIndent indent) override;
   
-  /**
-   * Set/Get the Interactor wrapper being controlled by this object.
-   * (Satisfy superclass API.)
-   */
+   /// Set the Interactor wrapper being controlled by this object. (Satisfy superclass API.)
   void SetInteractor(vtkRenderWindowInteractor *interactor) override;
 
-  /**
-   * Main process event method
-   */
+  /// Main process event method
   static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
 
   /// Get MRML scene from the displayable manager group (the first displayable manager's if any)
   vtkMRMLScene* GetMRMLScene();
 
   //@{
-  /**
-  * Override generic event bindings to call the corresponding action.
-  */
+  /// Override generic event bindings to call the corresponding action.
   void OnButton3D(vtkEventData *edata) override;
   void OnMove3D(vtkEventData *edata) override;
   //@}


### PR DESCRIPTION
Some users find it counterintuitive that the grip button does the basic functions while the trigger button does nothing. That change was made so that the trigger button is left for the laser and UI manipulation. Since those developments are delayed significantly, it makes sense to add back the "grip objects and world" function back to the trigger button as well.

It is done in a configurable way. The interactor style has a new SetTriggerButtonFunction method that takes a string. If the string is empty then the trigger button will not do anything. If it is the constant accessible with GetButtonFunctionStringGripObjectsAndWorld, then it will be the same as what the grip button currently does as well. The latter is the default for now.