### PR TITLE
BUG: Fixes issue on Oculus that throws error constantly when used

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
@@ -323,6 +323,10 @@ bool vtkVirtualRealityViewInteractorStyle::DelegateInteractionEventToDisplayable
   {
     interactionContextName = "RightController"; //TODO: Store these elsewhere
   }
+  else if (ed->GetDevice() == vtkEventDataDevice::HeadMountedDisplay)
+  {
+      interactionContextName = "HeadMountedDisplay";
+  }
   else
   {
     vtkErrorMacro("DelegateInteractionEventToDisplayableManagers: Unrecognized device");


### PR DESCRIPTION
vtkInteractorStyle::OnMove3D is called for controllers AND the head mounted display.

OnMove3D then calls DelegateInteractionEventToDisplayableManagers which has an if statement that throws errors if device is not a controller. Thus you would constantly get this error.