### PR TITLE
COMP: Fix build using renamed API to retrieve OpenVR pose

### DIFF
--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -528,7 +528,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodeWithControllerPose(vtkEv
   }
 
   vr::TrackedDevicePose_t* tdPose;
-  this->RenderWindow->GetTrackedDevicePose(device, &tdPose);
+  this->RenderWindow->GetOpenVRPose(device, &tdPose);
 
   if (tdPose == nullptr)
   {
@@ -576,7 +576,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodeWithHMDPose()
   }
 
   vr::TrackedDevicePose_t* tdPose;
-  this->RenderWindow->GetTrackedDevicePose(vtkEventDataDevice::HeadMountedDisplay, &tdPose);
+  this->RenderWindow->GetOpenVRPose(vtkEventDataDevice::HeadMountedDisplay, &tdPose);
 
   if (tdPose == nullptr)
   {
@@ -625,7 +625,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodesWithTrackerPoses()
 
     // Now, we have our generic tracker node, let's update it!
     vr::TrackedDevicePose_t* tdPose;
-    this->RenderWindow->GetTrackedDevicePose(vtkEventDataDevice::GenericTracker, dev, &tdPose);
+    this->RenderWindow->GetOpenVRPose(vtkEventDataDevice::GenericTracker, dev, &tdPose);
 
     if (tdPose == nullptr)
     {


### PR DESCRIPTION
This commit fixes a regression introduced in previous commit 87fc5f9 (BUG: Fix retrieval of OpenVR last post updating VTK) using the expected function name.