### PR TITLE
Fix interaction support renaming VR interactor style callback functions

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
@@ -69,8 +69,9 @@ public:
 
   //@{
   /// Override generic event bindings to call the corresponding action.
-  void OnButton3D(vtkEventData *edata) override;
+  void OnSelect3D(vtkEventData *edata) override;
   void OnMove3D(vtkEventData *edata) override;
+  void OnViewerMovement3D(vtkEventData* edata) override;
   //@}
 
   //@{
@@ -214,6 +215,11 @@ protected:
 protected:
   vtkVirtualRealityViewInteractorStyle();
   ~vtkVirtualRealityViewInteractorStyle() override;
+
+  /**
+   * Update the 3D movement according to the given interaction state.
+   */
+  void Movement3D(int interactionState, vtkEventData* edata);
 
 private:
   vtkVirtualRealityViewInteractorStyle(const vtkVirtualRealityViewInteractorStyle&);  /// Not implemented.


### PR DESCRIPTION
This commit initiates renaming of the interactor style event callback functions to support the action based input model introduced in https://github.com/Slicer/VTK/commit/b7f02e6225bff280c16f2abf44aca216fcaf973d

This commit adds support for `Select3DEvent` and `ViewerMovement3DEvent`.
 - Select3DEvent: The action performed when this event is fired is defined by calling MapInputToAction (see [1]).
 - ViewerMovement3DEvent: Gives users the ability to fly by calling Dolly3D(). VTK's interactor style offers additional behavior to move around.

[1] https://gitlab.kitware.com/vtk/vtk/-/blob/master/Rendering/VR/vtkVRInteractorStyle.cxx#L61

Future commits could focus on:
- Completing synchronization of this class with `vtkVRInteractorStyle`:
  - Add support for Grounded movement style for `ViewerMovement3DEvent`
  - Add support for `Elevation3DEvent`, `Pick3DEvent`, `Clip3DEvent`, `NextPose3DEvent`, `Menu3DEvent`

- Confirm that multi gesture events (Pan, Rotate and Pinch) are functional if pressing the grip buttons, and propose new approach to customize the gesture button in VTK. Multi-gesture is handled by the interactor but only triggered by grip buttons (see [2]). This deprecates the `vtkVirtualRealityViewInteractor::SetGestureButtonTo` function.

[2] https://github.com/Slicer/VTK/blob/slicer-v9.1.20220125-efbe2afc2/Rendering/VR/vtkVRRenderWindowInteractor.cxx#L366