### PR TITLE
BUG: Restore complex gesture support

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
@@ -40,81 +40,131 @@ vtkVirtualRealityViewInteractor::~vtkVirtualRealityViewInteractor()
 {
 }
 
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractor::HandleGripEvents(vtkEventData* ed)
+{
+  // [SlicerVirtualReality]
+  //
+  // SlicerVirtualReality implementation details:
+  //
+  // * The implementation of both HandleGripEvents() and RecognizeComplexGesture()
+  //   was updated by removing the handling specific to Rotate and Pan to only keep
+  //   he pinch event.
+  //
+  // * The update of the Scale was removed.
+  //
+  // * The lines either enclosed in `[SlicerVirtualReality]` or associated with a
+  //   `// SlicerVirtualReality` comment are specific to this extension.
+  //
+  // [/SlicerVirtualReality]
+
+  vtkEventDataDevice3D* edata = ed->GetAsEventDataDevice3D();
+  if (!edata)
+  {
+    return;
+  }
+
+  this->PointerIndex = static_cast<int>(edata->GetDevice());
+  if (edata->GetAction() == vtkEventDataAction::Press)
+  {
+    this->DeviceInputDownCount[this->PointerIndex] = 1;
+
+    this->StartingPhysicalEventPositions[this->PointerIndex][0] =
+      this->PhysicalEventPositions[this->PointerIndex][0];
+    this->StartingPhysicalEventPositions[this->PointerIndex][1] =
+      this->PhysicalEventPositions[this->PointerIndex][1];
+    this->StartingPhysicalEventPositions[this->PointerIndex][2] =
+      this->PhysicalEventPositions[this->PointerIndex][2];
+
+    // [SlicerVirtualReality]
+    // As originally described in SlicerVirtualReality@b6815f1cb, while the controllers
+    // move, the purpose is to have the PhysicalToWorld matrix modified so that the controller
+    // physical pose corresponds to the same rendering world pose.
+    //
+    // For reference, the "StartingPhysicalEventPoses" ivar was originally introduced in upstream
+    // VTK as VTK@803d3a327.
+    this->StartingPhysicalEventPoses[this->PointerIndex]->DeepCopy(
+      this->PhysicalEventPoses[this->PointerIndex]);
+    // [/SlicerVirtualReality]
+
+    vtkVRRenderWindow* renWin = vtkVRRenderWindow::SafeDownCast(this->RenderWindow);
+    renWin->GetPhysicalToWorldMatrix(this->StartingPhysicalToWorldMatrix);
+
+    // Both controllers have the grip down, start multitouch
+    if (this->DeviceInputDownCount[static_cast<int>(vtkEventDataDevice::LeftController)] &&
+      this->DeviceInputDownCount[static_cast<int>(vtkEventDataDevice::RightController)])
+    {
+      // The gesture is still unknown
+      this->CurrentGesture = vtkCommand::StartEvent;
+    }
+  }
+
+  // End the gesture if needed
+  if (edata->GetAction() == vtkEventDataAction::Release)
+  {
+    this->DeviceInputDownCount[this->PointerIndex] = 0;
+
+    if (edata->GetInput() == vtkEventDataDeviceInput::Grip)
+    {
+      if (this->CurrentGesture == vtkCommand::PinchEvent)
+      {
+        this->EndPinchEvent();
+      }
+      this->CurrentGesture = vtkCommand::NoEvent;
+
+      return;
+    }
+  }
+}
+
 //----------------------------------------------------------------------------
-/*
-void vtkVirtualRealityViewInteractor::RecognizeComplexGesture(vtkEventDataDevice3D* edata)
+void vtkVirtualRealityViewInteractor::RecognizeComplexGesture(vtkEventDataDevice3D* vtkNotUsed(edata))
 {
   // Recognize gesture only if one button is pressed per controller
-  if (this->DeviceInputDownCount[this->PointerIndex] > 2 ||
-    this->DeviceInputDownCount[this->PointerIndex] == 0)
+  int lhand = static_cast<int>(vtkEventDataDevice::LeftController);
+  int rhand = static_cast<int>(vtkEventDataDevice::RightController);
+
+  if (this->DeviceInputDownCount[lhand] > 1 || this->DeviceInputDownCount[lhand] == 0 ||
+    this->DeviceInputDownCount[rhand] > 1 || this->DeviceInputDownCount[rhand] == 0)
   {
     this->CurrentGesture = vtkCommand::NoEvent;
     return;
   }
 
-  // Store the initial positions
-  if (edata->GetType() == vtkCommand::Button3DEvent)
+  // [SlicerVirtualReality]
+  // double* posVals[2];
+  // double* startVals[2];
+  // posVals[0] = this->PhysicalEventPositions[lhand];
+  // posVals[1] = this->PhysicalEventPositions[rhand];
+
+  // startVals[0] = this->StartingPhysicalEventPositions[lhand];
+  // startVals[1] = this->StartingPhysicalEventPositions[rhand];
+  // [/SlicerVirtualReality]
+
+  if (this->CurrentGesture != vtkCommand::NoEvent)
   {
-    if (edata->GetAction() == vtkEventDataAction::Press)
+
+    // [SlicerVirtualReality]
+    // Calculate the distances
+    // double originalDistance = sqrt(vtkMath::Distance2BetweenPoints(startVals[0], startVals[1]));
+    // double newDistance = sqrt(vtkMath::Distance2BetweenPoints(posVals[0], posVals[1]));
+    // [/SlicerVirtualReality]
+
+    if (this->CurrentGesture == vtkCommand::StartEvent)
     {
-      this->StartingPhysicalEventPositions[this->PointerIndex][0] =
-        this->PhysicalEventPositions[this->PointerIndex][0];
-      this->StartingPhysicalEventPositions[this->PointerIndex][1] =
-        this->PhysicalEventPositions[this->PointerIndex][1];
-      this->StartingPhysicalEventPositions[this->PointerIndex][2] =
-        this->PhysicalEventPositions[this->PointerIndex][2];
-
-      this->StartingPhysicalEventPoses[this->PointerIndex]->DeepCopy(
-        this->PhysicalEventPoses[this->PointerIndex] );
-
-      vtkOpenVRRenderWindow* renWin =
-        vtkOpenVRRenderWindow::SafeDownCast(this->RenderWindow);
-      renWin->GetPhysicalToWorldMatrix(this->StartingPhysicalToWorldMatrix);
-
-      // Both controllers have the grip down, start multitouch
-      for (std::vector<int>::iterator buttonIt=this->GestureEnabledButtons.begin(); buttonIt!=this->GestureEnabledButtons.end(); ++buttonIt)
-      {
-        if (this->DeviceInputDown[*buttonIt][0] && this->DeviceInputDown[*buttonIt][1])
-        {
-          this->CurrentGesture = vtkCommand::PinchEvent;
-          this->StartPinchEvent();
-          break;
-        }
-      }
+      this->CurrentGesture = vtkCommand::PinchEvent;
+      // this->Scale = 1.0; // SlicerVirtualReality
+      this->StartPinchEvent();
     }
 
-    // End the gesture if needed
-    if (edata->GetAction() == vtkEventDataAction::Release)
-    {
-      for (std::vector<int>::iterator buttonIt=this->GestureEnabledButtons.begin(); buttonIt!=this->GestureEnabledButtons.end(); ++buttonIt)
-      {
-        if (edata->GetInput() == static_cast<vtkEventDataDeviceInput>(*buttonIt))
-        {
-          if (this->CurrentGesture == vtkCommand::PinchEvent)
-          {
-            this->EndPinchEvent();
-          }
-          this->CurrentGesture = vtkCommand::NoEvent;
-        }
-      }
-    }
-  }
-
-  if (edata->GetType() == vtkCommand::Move3DEvent && this->CurrentGesture != vtkCommand::NoEvent)
-  {
-    // Reduce computation
-    if (!this->PointerIndex)
-    {
-      return;
-    }
-
+    // If we have found a specific type of movement then handle it
     if (this->CurrentGesture == vtkCommand::PinchEvent)
     {
+      // this->SetScale(newDistance / originalDistance); // SlicerVirtualReality
       this->PinchEvent();
     }
   }
 }
-*/
 
 //----------------------------------------------------------------------------
 void vtkVirtualRealityViewInteractor::PrintSelf(ostream& os, vtkIndent indent)

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
@@ -42,12 +42,13 @@ public:
 
   virtual void SetInteractorStyle(vtkInteractorObserver*);
 
-  // TODO: Assess with this function should still be overriden with VTK 9.1
-  //
-  // Background: The function became non virtual in:
-  // * Kitware/VTK@af0fab486 (Clean up VR and OpenVR classes )
-  //
-  //virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata) override;
+  ///@{
+  /// Define Slicer specific heuristic for handling complex gestures.
+  ///
+  /// See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9892
+  virtual void HandleGripEvents(vtkEventData* ed) override;
+  virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata) override;
+  ///@}
 
   /// Set trigger button function
   /// By default it is the same as grab (\sa GetButtonFunctionIdForGrabObjectsAndWorld)


### PR DESCRIPTION
Following 1c36e4031 (ENH: Update integration to support VTK 9.1), VTK was updated to a version where RecognizeComplexGesture was not virtual anymore in the base class (due to the integration of kitware/VTK@af0fab486 (Clean up VR and OpenVR classes)).

This commit re-introduces the support for custom complex gesture handling based of VTK MR-9892.
See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9892

SlicerVirtualReality implementation details:

* The implementation of both `HandleGripEvents()` and `RecognizeComplexGesture()` was updated by removing the handling specific to Rotate and Pan to only keep he pinch event.

* The update of the Scale was removed.

* Call to `StartingPhysicalEventPoses()` originally introduced though both SlicerVirtualReality@b6815f1cb and kitware/VTK@803d3a327 was maintained. The `PhysicalToWorld` matrix is modified so that the controller physical pose corresponds to the same rendering world pose.

* The lines either enclosed in `[SlicerVirtualReality]` or associated with a `// SlicerVirtualReality` comment are specific to this extension.