### PR TITLE
COMP: Fix build accounting for vtkVirtualRealityViewInteractor API change

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
@@ -42,7 +42,7 @@ vtkVirtualRealityViewInteractor::~vtkVirtualRealityViewInteractor()
 }
 
 //------------------------------------------------------------------------------
-void vtkVirtualRealityViewInteractor::HandleGripEvents(vtkEventData* ed)
+void vtkVirtualRealityViewInteractor::HandleComplexGestureEvents(vtkEventData* ed)
 {
   // [SlicerVirtualReality]
   //

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
@@ -46,7 +46,7 @@ public:
   /// Define Slicer specific heuristic for handling complex gestures.
   ///
   /// See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9892
-  virtual void HandleGripEvents(vtkEventData* ed) override;
+  virtual void HandleComplexGestureEvents(vtkEventData* ed) override;
   virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata) override;
   ///@}
 


### PR DESCRIPTION
This commit renames the function from `HandleGripEvents` to `HandleComplexGestureEvents` to account for the change introduced through VTK MR-9892.

See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9892

It fixes error like the following:

```
In file included from /path/to/SlicerVirtualReality/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx:21: /path/to/SlicerVirtualReality/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h:49:16: error: ‘virtual void vtkVirtualRealityViewInteractor::HandleGripEvents(vtkEventData*)’ marked ‘override’, but does not override
   49 |   virtual void HandleGripEvents(vtkEventData* ed) override;
      |                ^~~~~~~~~~~~~~~~
```