### PR TITLE
BUG: Fix lookup of manifest file from build tree

### DIFF
--- a/VirtualReality/qSlicerVirtualRealityModule.cxx
+++ b/VirtualReality/qSlicerVirtualRealityModule.cxx
@@ -155,15 +155,15 @@ void qSlicerVirtualRealityModulePrivate::addViewWidget()
     //
     // and the action manifest files are in this directory
     //
-    //   <extension-build-dir>/vtkRenderingOpenVR-build/externals/vtkRenderingOpenVR/
+    //   <extension-build-dir>/vtkRenderingOpenVR-build/vtkRenderingOpenVR/
     //
     // we compose the path as such:
 
     // First, we retrieve <module-lib-dir>
     std::string moduleLibDirectory = vtkSlicerApplicationLogic::GetModuleSlicerXYLibDirectory(q->path().toStdString());
 
-    // ... then we change the directory to vtkRenderingOpenVR-build/externals/vtkRenderingOpenVR/
-    QString actionManifestPath = QString::fromStdString(moduleLibDirectory + "/../../../vtkRenderingOpenVR-build/externals/vtkRenderingOpenVR/");
+    // ... then we change the directory to vtkRenderingOpenVR-build/vtkRenderingOpenVR/
+    QString actionManifestPath = QString::fromStdString(moduleLibDirectory + "/../../../vtkRenderingOpenVR-build/vtkRenderingOpenVR/");
 
     this->VirtualRealityViewWidget->setActionManifestPath(actionManifestPath);
   }


### PR DESCRIPTION
Remove the "externals" sub-directory that was specific to branch Slicer/VTK@slicer-v9.1.20220125-efbe2afc2 integrating commit Slicer/VTK@0ba7af630 (`[Backport MR-8123] vtk_module_build: Ensure external modules build directory are not overwritten`)

Since the approach originally proposed in VTK MR-8123 was superseded by MR-9097 there is no need to specify the "externals" sub-directory.