### PR TITLE
BUG: Fix integration with updated Slicer event delegation and VTK OpenVR API

### DIFF
--- a/VirtualReality/MRML/CMakeLists.txt
+++ b/VirtualReality/MRML/CMakeLists.txt
@@ -18,6 +18,8 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}LayoutNode.h
   vtk${MODULE_NAME}ViewInteractor.cxx
   vtk${MODULE_NAME}ViewInteractor.h
+  vtk${MODULE_NAME}ViewInteractorObserver.cxx
+  vtk${MODULE_NAME}ViewInteractorObserver.h
   vtk${MODULE_NAME}ViewInteractorStyle.cxx
   vtk${MODULE_NAME}ViewInteractorStyle.h
   )

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -129,7 +129,7 @@ void vtkVirtualRealityViewInteractorObserver::CustomProcessEvents(vtkObject* obj
   vtkVirtualRealityViewInteractorObserver* self
     = reinterpret_cast<vtkVirtualRealityViewInteractorObserver *>(clientdata);
 
-  if (!self->DelegateInteractionEventToDisplayableManagers(event) || self->GetInteractorStyle()->GetState() != VTKIS_NONE)
+  if (!self->DelegateInteractionEventToDisplayableManagers(event, calldata))
     {
     // Displayable managers did not process it
     vtkVirtualRealityViewInteractorObserver::ProcessEvents(object, event, clientdata, calldata);
@@ -195,6 +195,28 @@ void vtkVirtualRealityViewInteractorObserver::ProcessEvents(
 //----------------------------------------------------------------------------
 // Generic events binding
 //----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventToDisplayableManagers(unsigned long event, void* calldata)
+{
+  vtkSmartPointer<vtkEventData> ed;
+  if (vtkCommand::EventHasData(event))
+    {
+    ed = vtkSmartPointer(static_cast<vtkEventData*>(calldata));
+    }
+  else
+    {
+    ed = vtkSmartPointer<vtkMRMLInteractionEventData>::New();
+    ed->SetType(event);
+    }
+
+  bool delegated = this->DelegateInteractionEventToDisplayableManagers(ed);
+  if (delegated)
+    {
+    this->EventCallbackCommand->SetAbortFlag(1);
+    }
+  return delegated;
+}
 
 //----------------------------------------------------------------------------
 bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData)

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -34,50 +34,18 @@
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkVirtualRealityViewInteractorObserver);
 
-//----------------------------------------------------------------------------
-class vtkVirtualRealityViewInteractorObserver::vtkInternal
-{
-public:
-  vtkInternal(vtkVirtualRealityViewInteractorObserver* external);
-  ~vtkInternal();
-
-public:
-  vtkVirtualRealityViewInteractorObserver* External{nullptr};
-  vtkCallbackCommand* EventCallbackCommand{nullptr};
-};
-
-
-//---------------------------------------------------------------------------
-// vtkInternal methods
-
-//---------------------------------------------------------------------------
-vtkVirtualRealityViewInteractorObserver::vtkInternal::vtkInternal(vtkVirtualRealityViewInteractorObserver* external)
-  : External(external)
-{
-  this->EventCallbackCommand = vtkCallbackCommand::New();
-  this->EventCallbackCommand->SetClientData(this->External);
-  this->EventCallbackCommand->SetCallback(vtkVirtualRealityViewInteractorObserver::CustomProcessEvents);
-}
-
-//---------------------------------------------------------------------------
-vtkVirtualRealityViewInteractorObserver::vtkInternal::~vtkInternal()
-{
-  this->EventCallbackCommand->Delete();
-}
-
 //---------------------------------------------------------------------------
 // vtkVirtualRealityViewInteractorObserver methods
 
 //----------------------------------------------------------------------------
 vtkVirtualRealityViewInteractorObserver::vtkVirtualRealityViewInteractorObserver()
 {
-  this->Internal = new vtkInternal(this);
+  this->EventCallbackCommand->SetCallback(vtkVirtualRealityViewInteractorObserver::CustomProcessEvents);
 }
 
 //----------------------------------------------------------------------------
 vtkVirtualRealityViewInteractorObserver::~vtkVirtualRealityViewInteractorObserver()
 {
-  delete this->Internal;
 }
 
 //----------------------------------------------------------------------------
@@ -93,11 +61,6 @@ void vtkVirtualRealityViewInteractorObserver::SetInteractor(vtkRenderWindowInter
     {
     return;
     }
-  // if we already have an Interactor then stop observing it
-  if (this->Interactor)
-    {
-    this->Interactor->RemoveObserver(this->Internal->EventCallbackCommand);
-    }
 
   this->Superclass::SetInteractor(interactor);
 
@@ -108,14 +71,14 @@ void vtkVirtualRealityViewInteractorObserver::SetInteractor(vtkRenderWindowInter
     /// 3D event bindings
     // Move3DEvent: Already observed in vtkMRMLViewInteractorStyle
     // Button3DEvent: Already observed in vtkMRMLViewInteractorStyle
-    interactor->AddObserver(vtkCommand::Menu3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::Select3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::NextPose3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::ViewerMovement3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::Pick3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::PositionProp3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::Clip3DEvent, this->Internal->EventCallbackCommand, priority);
-    interactor->AddObserver(vtkCommand::Elevation3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Menu3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Select3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::NextPose3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::ViewerMovement3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Pick3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::PositionProp3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Clip3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Elevation3DEvent, this->EventCallbackCommand, priority);
 
     /// Touch gesture interaction events
     // Already observed in vtkMRMLViewInteractorStyle

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -140,13 +140,22 @@ void vtkVirtualRealityViewInteractorObserver::CustomProcessEvents(vtkObject* obj
 void vtkVirtualRealityViewInteractorObserver::ProcessEvents(
   vtkObject* object, unsigned long event, void* clientdata, void* calldata)
 {
-  Superclass::ProcessEvents(object, event, clientdata, calldata);
-
   vtkVirtualRealityViewInteractorObserver* self =
     reinterpret_cast<vtkVirtualRealityViewInteractorObserver*>(clientdata);
 
   switch (event)
     {
+
+    case vtkCommand::StartPinchEvent:
+    case vtkCommand::StartRotateEvent:
+    case vtkCommand::StartPanEvent:
+      self->OnStartGesture();
+      break;
+    case vtkCommand::EndPinchEvent:
+    case vtkCommand::EndRotateEvent:
+    case vtkCommand::EndPanEvent:
+      self->OnEndGesture();
+      break;
 
     /// 3D event bindings
     // Move3DEvent: Already observed in vtkMRMLViewInteractorStyle
@@ -177,6 +186,7 @@ void vtkVirtualRealityViewInteractorObserver::ProcessEvents(
       break;
 
     default:
+      Superclass::ProcessEvents(object, event, clientdata, calldata);
       break;
     }
 }
@@ -247,6 +257,22 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
   ed->SetInteractionContextName(interactionContextName);
 
   return this->Superclass::DelegateInteractionEventDataToDisplayableManagers(ed);
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnStartGesture()
+{
+  vtkVirtualRealityViewInteractorStyle* vrInteractorStyle =
+      vtkVirtualRealityViewInteractorStyle::SafeDownCast(this->GetInteractorStyle());
+  vrInteractorStyle->OnStartGesture();
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnEndGesture()
+{
+  vtkVirtualRealityViewInteractorStyle* vrInteractorStyle =
+      vtkVirtualRealityViewInteractorStyle::SafeDownCast(this->GetInteractorStyle());
+  vrInteractorStyle->OnEndGesture();
 }
 
 //----------------------------------------------------------------------------

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -1,0 +1,298 @@
+/*==============================================================================
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+  and was supported through the University of Western Ontario.
+
+==============================================================================*/
+
+#include "vtkVirtualRealityViewInteractorObserver.h"
+
+// SlicerVirtualReality includes
+#include "vtkVirtualRealityViewInteractorStyle.h"
+
+// MRML includes
+#include "vtkMRMLInteractionEventData.h"
+
+// VTK includes
+#include <vtkCallbackCommand.h>
+#include <vtkEventData.h>
+#include <vtkInteractorStyle.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkObjectFactory.h>
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkVirtualRealityViewInteractorObserver);
+
+//----------------------------------------------------------------------------
+class vtkVirtualRealityViewInteractorObserver::vtkInternal
+{
+public:
+  vtkInternal(vtkVirtualRealityViewInteractorObserver* external);
+  ~vtkInternal();
+
+public:
+  vtkVirtualRealityViewInteractorObserver* External{nullptr};
+  vtkCallbackCommand* EventCallbackCommand{nullptr};
+};
+
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+
+//---------------------------------------------------------------------------
+vtkVirtualRealityViewInteractorObserver::vtkInternal::vtkInternal(vtkVirtualRealityViewInteractorObserver* external)
+  : External(external)
+{
+  this->EventCallbackCommand = vtkCallbackCommand::New();
+  this->EventCallbackCommand->SetClientData(this->External);
+  this->EventCallbackCommand->SetCallback(vtkVirtualRealityViewInteractorObserver::CustomProcessEvents);
+}
+
+//---------------------------------------------------------------------------
+vtkVirtualRealityViewInteractorObserver::vtkInternal::~vtkInternal()
+{
+  this->EventCallbackCommand->Delete();
+}
+
+//---------------------------------------------------------------------------
+// vtkVirtualRealityViewInteractorObserver methods
+
+//----------------------------------------------------------------------------
+vtkVirtualRealityViewInteractorObserver::vtkVirtualRealityViewInteractorObserver()
+{
+  this->Internal = new vtkInternal(this);
+}
+
+//----------------------------------------------------------------------------
+vtkVirtualRealityViewInteractorObserver::~vtkVirtualRealityViewInteractorObserver()
+{
+  delete this->Internal;
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::SetInteractor(vtkRenderWindowInteractor *interactor)
+{
+  if (interactor == this->Interactor)
+    {
+    return;
+    }
+  // if we already have an Interactor then stop observing it
+  if (this->Interactor)
+    {
+    this->Interactor->RemoveObserver(this->Internal->EventCallbackCommand);
+    }
+
+  this->Superclass::SetInteractor(interactor);
+
+  if (interactor)
+    {
+    float priority = 0.0f;
+
+    /// 3D event bindings
+    // Move3DEvent: Already observed in vtkMRMLViewInteractorStyle
+    // Button3DEvent: Already observed in vtkMRMLViewInteractorStyle
+    interactor->AddObserver(vtkCommand::Menu3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Select3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::NextPose3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::ViewerMovement3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Pick3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::PositionProp3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Clip3DEvent, this->Internal->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Elevation3DEvent, this->Internal->EventCallbackCommand, priority);
+
+    /// Touch gesture interaction events
+    // Already observed in vtkMRMLViewInteractorStyle
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::CustomProcessEvents(vtkObject* object,
+  unsigned long event, void* clientdata, void* calldata)
+{
+  vtkVirtualRealityViewInteractorObserver* self
+    = reinterpret_cast<vtkVirtualRealityViewInteractorObserver *>(clientdata);
+
+  if (!self->DelegateInteractionEventToDisplayableManagers(event) || self->GetInteractorStyle()->GetState() != VTKIS_NONE)
+    {
+    // Displayable managers did not process it
+    vtkVirtualRealityViewInteractorObserver::ProcessEvents(object, event, clientdata, calldata);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::ProcessEvents(
+  vtkObject* object, unsigned long event, void* clientdata, void* calldata)
+{
+  Superclass::ProcessEvents(object, event, clientdata, calldata);
+
+  vtkVirtualRealityViewInteractorObserver* self =
+    reinterpret_cast<vtkVirtualRealityViewInteractorObserver*>(clientdata);
+
+  switch (event)
+    {
+
+    /// 3D event bindings
+    // Move3DEvent: Already observed in vtkMRMLViewInteractorStyle
+    // Button3DEvent: Already observed in vtkMRMLViewInteractorStyle
+    case vtkCommand::Menu3DEvent:
+      self->OnMenu3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::Select3DEvent:
+      self->OnSelect3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::NextPose3DEvent:
+      self->OnNextPose3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::ViewerMovement3DEvent:
+      self->OnViewerMovement3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::Pick3DEvent:
+      self->OnPick3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::PositionProp3DEvent:
+      self->OnPositionProp3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::Clip3DEvent:
+      self->OnClip3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::Elevation3DEvent:
+      self->OnElevation3D(static_cast<vtkEventData*>(calldata));
+      break;
+
+    default:
+      break;
+    }
+}
+
+
+//----------------------------------------------------------------------------
+// Generic events binding
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData)
+{
+  // Get display and world position
+  if (!inputEventData)
+    {
+    return false;
+    }
+  int* displayPositionInt = this->GetInteractor()->GetEventPosition();
+  vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(displayPositionInt[0], displayPositionInt[1]);
+  if (!pokedRenderer)
+    {
+    // can happen during application shutdown
+    return false;
+    }
+
+  vtkEventDataDevice3D* inputEventDataDevice3D = inputEventData->GetAsEventDataDevice3D();
+  if (!inputEventDataDevice3D)
+    {
+    vtkErrorMacro("DelegateInteractionEventToDisplayableManagers: Invalid event data type");
+    return false;
+    }
+
+  return this->Superclass::DelegateInteractionEventToDisplayableManagers(inputEventData);
+}
+
+//----------------------------------------------------------------------------
+bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisplayableManagers(vtkMRMLInteractionEventData* ed)
+{
+
+  vtkVirtualRealityViewInteractorStyle* vrViewInteractorStyle =
+      vtkVirtualRealityViewInteractorStyle::SafeDownCast(this->GetInteractorStyle());
+  if (vrViewInteractorStyle)
+    {
+    ed->SetWorldToPhysicalScale(vrViewInteractorStyle->GetMagnification());
+    ed->SetAccuratePicker(vrViewInteractorStyle->GetAccuratePicker());
+    }
+
+  vtkRenderer* currentRenderer = this->GetInteractorStyle()->GetCurrentRenderer();
+  ed->SetRenderer(currentRenderer);
+
+  std::string interactionContextName;
+  if (ed->GetDevice() == vtkEventDataDevice::LeftController)
+    {
+    interactionContextName = "LeftController"; //TODO: Store these elsewhere
+    }
+  else if (ed->GetDevice() == vtkEventDataDevice::RightController)
+    {
+    interactionContextName = "RightController"; //TODO: Store these elsewhere
+    }
+  else if (ed->GetDevice() == vtkEventDataDevice::HeadMountedDisplay)
+    {
+      interactionContextName = "HeadMountedDisplay";
+    }
+  else
+    {
+    vtkErrorMacro("DelegateInteractionEventDataToDisplayableManagers: Unrecognized device");
+    }
+  ed->SetInteractionContextName(interactionContextName);
+
+  return this->Superclass::DelegateInteractionEventDataToDisplayableManagers(ed);
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnMenu3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnMenu3D(edata);
+}
+
+//----------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnSelect3D(vtkEventData* edata)
+{
+  this->GetInteractorStyle()->OnSelect3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnNextPose3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnNextPose3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnViewerMovement3D(vtkEventData* edata)
+{
+  this->GetInteractorStyle()->OnViewerMovement3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnPick3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnPick3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnPositionProp3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnPositionProp3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnClip3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnClip3D(edata);
+}
+
+//------------------------------------------------------------------------------
+void vtkVirtualRealityViewInteractorObserver::OnElevation3D(vtkEventData *edata)
+{
+  this->GetInteractorStyle()->OnElevation3D(edata);
+}

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
@@ -56,6 +56,10 @@ public:
   /// Process events not already delegated to displayable managers by CustomProcessEvents().
   static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
 
+  /// ComplexGesture bindings
+  virtual void OnStartGesture();
+  virtual void OnEndGesture();
+
   /// 3D event bindings
   // OnMove3D: Already implemented in vtkMRMLViewInteractorStyle
   // OnButton3D: Already implemented in vtkMRMLViewInteractorStyle

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
@@ -1,0 +1,83 @@
+/*==============================================================================
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+  and was supported through the University of Western Ontario.
+
+==============================================================================*/
+
+#ifndef __vtkVirtualRealityViewInteractorObserver_h
+#define __vtkVirtualRealityViewInteractorObserver_h
+
+// MRML includes
+#include "vtkMRMLViewInteractorStyle.h"
+
+#include "vtkSlicerVirtualRealityModuleMRMLExport.h"
+
+class VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT vtkVirtualRealityViewInteractorObserver :
+    public vtkMRMLViewInteractorStyle
+{
+public:
+  static vtkVirtualRealityViewInteractorObserver *New();
+  vtkTypeMacro(vtkVirtualRealityViewInteractorObserver,vtkMRMLViewInteractorStyle);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Give a chance to displayable managers to process the event.
+  /// It just creates vtkMRMLInteractionEventData and calls
+  /// DelegateInteractionEventDataToDisplayableManagers.
+  /// Return true if the event is processed.
+  using vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers;
+  bool DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData) override;
+
+  /// Give a chance to displayable managers to process the event.
+  /// Return true if the event is processed.
+  using vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManagers;
+  virtual bool DelegateInteractionEventDataToDisplayableManagers(vtkMRMLInteractionEventData* eventData) override;
+
+  /// Set the Interactor wrapper being controlled by this object. (Satisfy superclass API.)
+  void SetInteractor(vtkRenderWindowInteractor *interactor) override;
+
+  /// Main process event method.
+  ///
+  /// If calling DelegateInteractionEventToDisplayableManagers() returns false or if the current motion flag
+  /// returned by vtkInteractorStyle::GetState() is VTKIS_NONE, call ProcessEvents().
+  static void CustomProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
+
+  /// Process events not already delegated to displayable managers by CustomProcessEvents().
+  static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
+
+  /// 3D event bindings
+  // OnMove3D: Already implemented in vtkMRMLViewInteractorStyle
+  // OnButton3D: Already implemented in vtkMRMLViewInteractorStyle
+  virtual void OnMenu3D(vtkEventData *edata);
+  virtual void OnSelect3D(vtkEventData *edata);
+  virtual void OnNextPose3D(vtkEventData *edata);
+  virtual void OnViewerMovement3D(vtkEventData *edata);
+  virtual void OnPick3D(vtkEventData *edata);
+  virtual void OnPositionProp3D(vtkEventData *edata);
+  virtual void OnClip3D(vtkEventData *edata);
+  virtual void OnElevation3D(vtkEventData *edata);
+
+protected:
+  vtkVirtualRealityViewInteractorObserver();
+  ~vtkVirtualRealityViewInteractorObserver() override;
+
+private:
+  vtkVirtualRealityViewInteractorObserver(const vtkVirtualRealityViewInteractorObserver&) = delete;
+  void operator=(const vtkVirtualRealityViewInteractorObserver&) = delete;
+
+  class vtkInternal;
+  vtkInternal* Internal;
+};
+
+#endif

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
@@ -32,11 +32,20 @@ public:
   vtkTypeMacro(vtkVirtualRealityViewInteractorObserver,vtkMRMLViewInteractorStyle);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
+  using vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers;
+
   /// Give a chance to displayable managers to process the event.
-  /// It just creates vtkMRMLInteractionEventData and calls
+  /// Based on the return of vtkCommand::EventHasData(event), it either casts the
+  /// calldata to a vtkEventData or just creates a one of type vtkMRMLInteractionEventData.
+  /// In both case, it calls DelegateInteractionEventDataToDisplayableManagers
+  /// passing a vtkEventData object.
+  /// Return true if the event is processed.
+  virtual bool DelegateInteractionEventToDisplayableManagers(unsigned long event, void* calldata);
+
+  /// Give a chance to displayable managers to process the event.
+  /// It creates vtkMRMLInteractionEventData and calls
   /// DelegateInteractionEventDataToDisplayableManagers.
   /// Return true if the event is processed.
-  using vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers;
   bool DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData) override;
 
   /// Give a chance to displayable managers to process the event.

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
@@ -22,16 +22,19 @@
 #define __vtkVirtualRealityViewInteractorStyle_h
 
 // MRML includes
-#include "vtkMRMLDisplayableManagerGroup.h"
 #include "vtkMRMLViewInteractorStyle.h"
 
 // VTK includes
+#include <vtkCellPicker.h>
+#include <vtkOpenVRInteractorStyle.h>
 #include "vtkObject.h"
 #include "vtkEventData.h"
+#include <vtkSmartPointer.h>
 
 #include "vtkSlicerVirtualRealityModuleMRMLExport.h"
 
 class vtkMRMLScene;
+class vtkMRMLDisplayableManagerGroup;
 class vtkCellPicker;
 class vtkWorldPointPicker;
 
@@ -40,28 +43,17 @@ class vtkWorldPointPicker;
 /// TODO:
 ///
 class VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT vtkVirtualRealityViewInteractorStyle :
-    public vtkMRMLViewInteractorStyle
+    public vtkOpenVRInteractorStyle
 {
 public:
   static vtkVirtualRealityViewInteractorStyle *New();
-  vtkTypeMacro(vtkVirtualRealityViewInteractorStyle,vtkMRMLViewInteractorStyle);
+  vtkTypeMacro(vtkVirtualRealityViewInteractorStyle,vtkOpenVRInteractorStyle);
   void PrintSelf(ostream& os, vtkIndent indent) override;
-  
-  /// Give a chance to displayable managers to process the event.
-  /// Return true if the event is processed.
-  using vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers;
-  bool DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData) override;
 
   /// Set the Interactor wrapper being controlled by this object. (Satisfy superclass API.)
   void SetInteractor(vtkRenderWindowInteractor *interactor) override;
 
-  /// Main process event method
-  static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
-
-  /**
-   * Setup default actions defined with an action path and a corresponding command.
-   */
-  void SetupActions(vtkRenderWindowInteractor* iren);
+  void SetDisplayableManagers(vtkMRMLDisplayableManagerGroup* displayableManagers);
 
   /// Get MRML scene from the displayable manager group (the first displayable manager's if any)
   vtkMRMLScene* GetMRMLScene();
@@ -77,14 +69,8 @@ public:
   /**
   * Interaction mode entry points.
   */
-  //virtual void StartPick(vtkEventDataDevice3D *);
-  //virtual void EndPick(vtkEventDataDevice3D *);
-  //virtual void StartLoadCamPose(vtkEventDataDevice3D *);
-  //virtual void EndLoadCamPose(vtkEventDataDevice3D *);
   virtual void StartPositionProp(vtkEventDataDevice3D *);
   virtual void EndPositionProp(vtkEventDataDevice3D *);
-  //virtual void StartClip(vtkEventDataDevice3D *);
-  //virtual void EndClip(vtkEventDataDevice3D *);
   virtual void StartDolly3D(vtkEventDataDevice3D *);
   virtual void EndDolly3D(vtkEventDataDevice3D *);
   //@}
@@ -105,7 +91,6 @@ public:
   /**
   * Methods for interaction.
   */
-  //void LoadNextCameraPose();
   void PositionProp(vtkEventData *, double* lwpos = nullptr, double* lwori = nullptr) override;
   //@}
 
@@ -115,45 +100,18 @@ public:
   * Actions are defined by a VTKIS_*STATE*, interaction entry points,
   * and the corresponding method for interaction.
   */
-  void MapInputToAction(vtkEventDataDevice device,
-    vtkEventDataDeviceInput input, int state);
-  int GetMappedAction(vtkEventDataDevice device, vtkEventDataDeviceInput input);
+  int GetMappedAction(vtkCommand::EventIds eid);
   //@}
-
-  ////@{
-  ///**
-  //* Define the helper text that goes with an input
-  //*/
-  //void AddTooltipForInput(vtkEventDataDevice device,
-  //  vtkEventDataDeviceInput input, const std::string &text);
-  ////@}
-
-  //vtkSetClampMacro(HoverPick, int, 0, 1);
-  //vtkGetMacro(HoverPick, int);
-  //vtkBooleanMacro(HoverPick, int);
 
   vtkSetClampMacro(GrabEnabled, int, 0, 1);
   vtkGetMacro(GrabEnabled, int);
   vtkBooleanMacro(GrabEnabled, int);
 
-  //int GetInteractionState(vtkEventDataDevice device) {
-  //  return this->InteractionState[static_cast<int>(device)]; }
-
-  //void ShowRay(vtkEventDataDevice controller);
-  //void HideRay(vtkEventDataDevice controller);
-
-  //void ShowBillboard(const std::string &text);
-  //void HideBillboard();
-
-  //void ShowPickSphere(double *pos, double radius, vtkProp3D *);
-  //void ShowPickCell(vtkCell *cell, vtkProp3D *);
-  //void HidePickActor();
-
-  //void ToggleDrawControls();
-
   //// allow the user to add options to the menu
   //vtkOpenVRMenuWidget *GetMenu() {
   //  return this->Menu.Get(); }
+
+  vtkCellPicker* GetAccuratePicker();
   
   /// Set physical to world magnification. Valid value range is [0.01, 100].
   /// Note: Conversion is physicalScale = 1000 / magnification
@@ -161,47 +119,14 @@ public:
   double GetMagnification();
 
 protected:
-  //void EndPickCallback(vtkSelection *sel);
-
-  ////Ray drawing
-  //void UpdateRay(vtkEventDataDevice controller);
-
-  //vtkNew<vtkOpenVRMenuWidget> Menu;
-  //vtkNew<vtkOpenVRMenuRepresentation> MenuRepresentation;
-  //vtkCallbackCommand* MenuCommand;
-  //static void MenuCallback(vtkObject* object,
-  //                  unsigned long event,
-  //                  void* clientdata,
-  //                  void* calldata);
-
-  //vtkNew<vtkTextActor3D> TextActor3D;
-  //vtkNew<vtkActor> PickActor;
-  //vtkNew<vtkSphereSource> Sphere;
-
-  // Device input to interaction state mapping
-  int InputMap[vtkEventDataNumberOfDevices][vtkEventDataNumberOfInputs];
-  //vtkOpenVRControlsHelper* ControlsHelpers[vtkEventDataNumberOfDevices][vtkEventDataNumberOfInputs];
 
   // Utility routines
   void StartAction(int VTKIS_STATE, vtkEventDataDevice3D *edata);
   void EndAction(int VTKIS_STATE, vtkEventDataDevice3D *edata);
 
-  ///**
-  //* Controls helpers drawing
-  //*/
-  //void AddTooltipForInput(vtkEventDataDevice device, vtkEventDataDeviceInput input);
-
   bool QuickPick(int x, int y, double pickPoint[3]);
 
 protected:
-  ///**
-  //* Indicates if picking should be updated every frame. If so, the interaction
-  //* picker will try to pick a prop and rays will be updated accordingly.
-  //* Default is set to off.
-  //*/
-  //int HoverPick;
-
-  //vtkNew<vtkOpenVRHardwarePicker> HardwarePicker;
 
   /// For jump to slice feature (when mouse is moved while shift key is pressed)
   vtkSmartPointer<vtkCellPicker> AccuratePicker;
@@ -217,6 +142,8 @@ protected:
    * Update the 3D movement according to the given interaction state.
    */
   void Movement3D(int interactionState, vtkEventData* edata);
+
+  vtkWeakPointer<vtkMRMLDisplayableManagerGroup> DisplayableManagers;
 
 private:
   vtkVirtualRealityViewInteractorStyle(const vtkVirtualRealityViewInteractorStyle&);  /// Not implemented.

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.h
@@ -39,6 +39,7 @@ class vtkCollection;
 class vtkGenericOpenGLRenderWindow;
 class vtkRenderWindowInteractor;
 class vtkSlicerCamerasModuleLogic;
+class vtkVirtualRealityViewInteractorObserver;
 
 class vtkOpenVRRenderer;
 class vtkOpenVRRenderWindow;
@@ -63,6 +64,9 @@ public:
   /// Constructors
   explicit qMRMLVirtualRealityView(QWidget* parent = nullptr);
   virtual ~qMRMLVirtualRealityView();
+
+  /// Returns the interactor observer of the view
+  Q_INVOKABLE vtkVirtualRealityViewInteractorObserver* interactorObserver()const;
 
   /// Add a displayable manager to the view,
   /// the displayable manager is proper to the 3D view and is not shared

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -57,6 +57,7 @@ class vtkOpenVRInteractorStyle;
 class vtkOpenVRRenderWindowInteractor;
 class vtkTimerLog;
 class vtkVirtualRealityViewInteractor;
+class vtkVirtualRealityViewInteractorObserver;
 class vtkVirtualRealityViewInteractorStyle;
 
 namespace vr
@@ -99,6 +100,7 @@ protected:
   vtkSlicerCamerasModuleLogic* CamerasLogic;
 
   vtkSmartPointer<vtkMRMLDisplayableManagerGroup> DisplayableManagerGroup;
+  vtkSmartPointer<vtkVirtualRealityViewInteractorObserver>  InteractorObserver;
   vtkWeakPointer<vtkMRMLVirtualRealityViewNode> MRMLVirtualRealityViewNode;
   vtkSmartPointer<vtkOpenVRRenderer> Renderer;
   vtkSmartPointer<vtkOpenVRRenderWindow> RenderWindow;


### PR DESCRIPTION
Addressing issues highlighted in Slicer/Slicer@1cc3b2c62, this commit introduces the `vtkVirtualRealityViewInteractorObserver` class. This addition streamlines event delegation to MRML displayable managers and their associated widgets by leveraging observation of the interactor style.

The modification enables the `vtkVirtualRealityViewInteractorStyle` to inherit from `vtkOpenVRInteractorStyle`, eliminating the need for redundant code implementation and duplication.

It also updates the use of `MapInputToAction()` to map "eventId to state" following the VTK refactoring introduced in kitware/VTK@b7f02e622 (`update openvr to action based input model`).

------------

This is also required the following VTK commit[^1]:

```
[SlicerVirtualReality] ENH: Update OpenVR json binding to map right and left trigger with triggeraction

This is required to support using the trigger button for complex gesture.
See vtkVirtualRealityViewInteractor::SetGestureButtonToTrigger()

Co-authored-by: Lucas Gandel <lucas.gandel@kitware.com>
```

**Update:** The corresponding changes along with the latest `V/OpenVR/OpenXR` VTK updates have been integrated into `Slicer/VTK` through https://github.com/Slicer/VTK/pull/46 and in `Slicer` through https://github.com/Slicer/Slicer/pull/7487

[^1]: <del>https://github.com/Slicer/VTK/compare/slicer-v9.2.20230607-1ff325c54-2...Slicer:VTK:slicer-v9.2.20230607-1ff325c54-2_slicervr-pr-131</del>