### PR TITLE
ENH: Always discard display position for 3D Event

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -219,6 +219,9 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
     ed->SetAccuratePicker(vrViewInteractorStyle->GetAccuratePicker());
     }
 
+  // Assumes event are all 3D and invalidates display position
+  ed->SetDisplayPositionInvalid();
+
   vtkRenderer* currentRenderer = this->GetInteractorStyle()->GetCurrentRenderer();
   ed->SetRenderer(currentRenderer);
 


### PR DESCRIPTION
Adapted from Slicer/Slicer@a0ad2a328 (`ENH: Handle 3D events in MRML interactor style and markups VTK widgets`)