### PR TITLE
BUG: Do not report "Unrecognized device" if handling complex gesture

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
@@ -42,6 +42,12 @@ vtkVirtualRealityViewInteractor::~vtkVirtualRealityViewInteractor()
 }
 
 //------------------------------------------------------------------------------
+vtkCommand::EventIds vtkVirtualRealityViewInteractor::GetCurrentGesture() const
+{
+  return this->CurrentGesture;
+}
+
+//------------------------------------------------------------------------------
 void vtkVirtualRealityViewInteractor::HandleComplexGestureEvents(vtkEventData* ed)
 {
   // [SlicerVirtualReality]

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.h
@@ -42,6 +42,12 @@ public:
 
   virtual void SetInteractorStyle(vtkInteractorObserver*) override;
 
+  /// Return the identifier of the complex gesture being handled.
+  /// \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+  /// \sa vtkVirtualRealityViewInteractorStyle::OnStartGesture()
+  /// \sa vtkVirtualRealityViewInteractorStyle::OnEndGesture()
+  vtkCommand::EventIds GetCurrentGesture() const;
+
   ///@{
   /// Define Slicer specific heuristic for handling complex gestures.
   ///

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -19,6 +19,7 @@
 #include "vtkVirtualRealityViewInteractorObserver.h"
 
 // SlicerVirtualReality includes
+#include "vtkVirtualRealityViewInteractor.h"
 #include "vtkVirtualRealityViewInteractorStyle.h"
 
 // MRML includes
@@ -222,6 +223,9 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
   vtkRenderer* currentRenderer = this->GetInteractorStyle()->GetCurrentRenderer();
   ed->SetRenderer(currentRenderer);
 
+  vtkVirtualRealityViewInteractor* vrViewInteractor =
+      vtkVirtualRealityViewInteractor::SafeDownCast(this->GetInteractor());
+
   std::string interactionContextName;
   if (ed->GetDevice() == vtkEventDataDevice::LeftController)
     {
@@ -235,8 +239,9 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
     {
       interactionContextName = "HeadMountedDisplay";
     }
-  else
+  else if (vrViewInteractor && vrViewInteractor->GetCurrentGesture() == vtkCommand::NoEvent)
     {
+    // Report an error message only if the interactor is not processing a complex gesture.
     vtkErrorMacro("DelegateInteractionEventDataToDisplayableManagers: Unrecognized device");
     }
   ed->SetInteractionContextName(interactionContextName);


### PR DESCRIPTION
Since complex gesture are not associated with a specific controller, the associated event will be a synthesized one not associated with any particular device.