### PR TITLE
ENH: Invoke "(Start/End)Gesture" from the gesture recognition handler

### DIFF
--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractor.cxx
@@ -114,6 +114,11 @@ void vtkVirtualRealityViewInteractor::HandleComplexGestureEvents(vtkEventData* e
     if (this->CurrentGesture == vtkCommand::PinchEvent)
     {
       this->EndPinchEvent();
+      vtkInteractorStyle* interactorStyle = vtkInteractorStyle::SafeDownCast(this->InteractorStyle);
+      if (interactorStyle)
+        {
+        interactorStyle->EndGesture();
+        }
     }
     this->CurrentGesture = vtkCommand::NoEvent;
 
@@ -159,6 +164,11 @@ void vtkVirtualRealityViewInteractor::RecognizeComplexGesture(vtkEventDataDevice
       this->CurrentGesture = vtkCommand::PinchEvent;
       // this->Scale = 1.0; // SlicerVirtualReality
       this->StartPinchEvent();
+      vtkInteractorStyle* interactorStyle = vtkInteractorStyle::SafeDownCast(this->InteractorStyle);
+      if (interactorStyle)
+        {
+        interactorStyle->StartGesture();
+        }
     }
 
     // If we have found a specific type of movement then handle it

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.cxx
@@ -109,18 +109,6 @@ void vtkVirtualRealityViewInteractorObserver::ProcessEvents(
 
   switch (event)
     {
-
-    case vtkCommand::StartPinchEvent:
-    case vtkCommand::StartRotateEvent:
-    case vtkCommand::StartPanEvent:
-      self->OnStartGesture();
-      break;
-    case vtkCommand::EndPinchEvent:
-    case vtkCommand::EndRotateEvent:
-    case vtkCommand::EndPanEvent:
-      self->OnEndGesture();
-      break;
-
     /// 3D event bindings
     // Move3DEvent: Already observed in vtkMRMLViewInteractorStyle
     // Button3DEvent: Already observed in vtkMRMLViewInteractorStyle
@@ -247,22 +235,6 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
   ed->SetInteractionContextName(interactionContextName);
 
   return this->Superclass::DelegateInteractionEventDataToDisplayableManagers(ed);
-}
-
-//----------------------------------------------------------------------------
-void vtkVirtualRealityViewInteractorObserver::OnStartGesture()
-{
-  vtkVirtualRealityViewInteractorStyle* vrInteractorStyle =
-      vtkVirtualRealityViewInteractorStyle::SafeDownCast(this->GetInteractorStyle());
-  vrInteractorStyle->OnStartGesture();
-}
-
-//----------------------------------------------------------------------------
-void vtkVirtualRealityViewInteractorObserver::OnEndGesture()
-{
-  vtkVirtualRealityViewInteractorStyle* vrInteractorStyle =
-      vtkVirtualRealityViewInteractorStyle::SafeDownCast(this->GetInteractorStyle());
-  vrInteractorStyle->OnEndGesture();
 }
 
 //----------------------------------------------------------------------------

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorObserver.h
@@ -65,10 +65,6 @@ public:
   /// Process events not already delegated to displayable managers by CustomProcessEvents().
   static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
 
-  /// ComplexGesture bindings
-  virtual void OnStartGesture();
-  virtual void OnEndGesture();
-
   /// 3D event bindings
   // OnMove3D: Already implemented in vtkMRMLViewInteractorStyle
   // OnButton3D: Already implemented in vtkMRMLViewInteractorStyle

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.cxx
@@ -747,7 +747,7 @@ void vtkVirtualRealityViewInteractorStyle::OnPinch3D()
 }
 
 //----------------------------------------------------------------------------
-void vtkVirtualRealityViewInteractorStyle::OnStartGesture()
+void vtkVirtualRealityViewInteractorStyle::StartGesture()
 {
   // Store combined starting controller pose
   vtkOpenVRRenderWindowInteractor* rwi = static_cast<vtkOpenVRRenderWindowInteractor*>(this->Interactor);
@@ -771,7 +771,7 @@ void vtkVirtualRealityViewInteractorStyle::OnStartGesture()
 }
 
 //----------------------------------------------------------------------------
-void vtkVirtualRealityViewInteractorStyle::OnEndGesture()
+void vtkVirtualRealityViewInteractorStyle::EndGesture()
 {
   this->Internal->StartingControllerPoseValid = false;
   this->Internal->LastValidCombinedControllerPoseExists = false;

--- a/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
+++ b/VirtualReality/MRML/vtkVirtualRealityViewInteractorStyle.h
@@ -83,8 +83,8 @@ public:
   void OnPinch() override;
   void OnRotate() override;
   void OnPinch3D();
-  void OnStartGesture();
-  void OnEndGesture();
+  void StartGesture() override;
+  void EndGesture() override;
   //@}
 
   //@{


### PR DESCRIPTION
The functions `OnStartGesture()` and `OnEndGesture()` have been renamed to `StartGesture()` and `EndGesture()`. This aligns their signatures with the corresponding virtual functions in the `vtkInteractorStyle` class. Subsequently, these functions are now called from the VR interactor style functions `HandleComplexGestureEvents()` and `RecognizeComplexGesture()`.