### PR TITLE
DOC: Update comments and docstrings in `vtkMRMLVirtualRealityViewNode` and `qMRMLVirtualRealityView`

### DIFF
--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -441,7 +441,7 @@ void vtkMRMLVirtualRealityViewNode::CreateDefaultControllerTransformNodes()
 
   if (!this->GetLeftControllerTransformNodeID())
   {
-    // We create or get and update the linear transform nodes that correspond to left and right controllers
+    // Create or get and update the linear transform node that correspond to left controller
     vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(this->GetScene()->GetSingletonNode("VirtualReality.LeftController", "vtkMRMLLinearTransformNode"));
     if (linearTransformNode == nullptr)
     {
@@ -456,6 +456,7 @@ void vtkMRMLVirtualRealityViewNode::CreateDefaultControllerTransformNodes()
 
   if (!this->GetRightControllerTransformNodeID())
   {
+    // Create or get and update the linear transform node that correspond to right controller
     vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(this->GetScene()->GetSingletonNode("VirtualReality.RightController", "vtkMRMLLinearTransformNode"));
     if (linearTransformNode == nullptr)
     {
@@ -479,7 +480,7 @@ void vtkMRMLVirtualRealityViewNode::CreateDefaultHMDTransformNode()
 
   if (!this->GetHMDTransformNodeID())
   {
-    // We create or get and update the linear transform nodes that correspond to left and right controllers
+    // Create or get and update the linear transform node that correspond to head-mounted display (HMD)
     vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(this->GetScene()->GetSingletonNode("VirtualReality.HMD", "vtkMRMLLinearTransformNode"));
     if (linearTransformNode == nullptr)
     {

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -58,9 +58,11 @@ public:
   /// Update the references of the node to the scene.
   void SetSceneReferences() override;
 
+  ///@{
   /// Return the color the view nodes have for the background by default.
   static double* defaultBackgroundColor();
   static double* defaultBackgroundColor2();
+  ///}@
 
   /// Get reference view node.
   /// Reference view node is a regular 3D view node, which content
@@ -131,61 +133,82 @@ public:
   /// \sa SetAndObserveTrackerTransformNode
   void RemoveAllTrackerTransformNodes();
 
+  ///@{
   /// Controls two-sided lighting property of the renderer
   vtkGetMacro(TwoSidedLighting, bool);
   vtkSetMacro(TwoSidedLighting, bool);
   vtkBooleanMacro(TwoSidedLighting, bool);
+  ///}@
 
+  ///@{
   /// If enabled then 4 lights are used, otherwise just 2.
   vtkGetMacro(BackLights, bool);
   vtkSetMacro(BackLights, bool);
   vtkBooleanMacro(BackLights, bool);
+  ///}@
 
+  ///@{
   /// Desired frame rate. Volume renderer may use this information
   /// for determining sampling distances (and other LOD actors, to
   /// determine display quality).
   vtkGetMacro(DesiredUpdateRate, double);
   vtkSetMacro(DesiredUpdateRate, double);
+  ///}@
 
+  ///@{
   /// Magnification of world [0.01, 100].
   /// Value greater than 1 means that objects appear larger in VR than their real world size.
   /// Translated to physical scale of the VR render window
   vtkGetMacro(Magnification, double);
   vtkSetMacro(Magnification, double);
+  ///}@
 
+  ///@{
   /// Motion speed of fly (i.e. dolly) in meters per second.
   /// Default is walking speed: 6 km/h = 1.66 m/s
   vtkGetMacro(MotionSpeed, double);
   vtkSetMacro(MotionSpeed, double);
+  ///}@
 
   /// Motion sensitivity (between 0.0 and 1.0).
   /// If virtual reality headset is not moving then update rate
   /// is decreased to allow higher quality rendering.
   vtkGetMacro(MotionSensitivity, double);
   vtkSetMacro(MotionSensitivity, double);
+  ///}@
 
+  ///@{
   /// If enabled then pose of controllers are saved in the scene as transforms.
   vtkGetMacro(ControllerTransformsUpdate, bool);
   void SetControllerTransformsUpdate(bool enable);
   vtkBooleanMacro(ControllerTransformsUpdate, bool);
+  ///}@
 
+  ///@{
   vtkGetMacro(HMDTransformUpdate, bool);
   void SetHMDTransformUpdate(bool enable);
   vtkBooleanMacro(HMDTransformUpdate, bool);
+  ///}@
 
+  ///@{
   vtkGetMacro(TrackerTransformUpdate, bool);
   void SetTrackerTransformUpdate(bool enable);
   vtkBooleanMacro(TrackerTransformUpdate, bool);
+  ///}@
 
+  ///@{
   /// If set to true then controllers are visible in virtual reality view.
   vtkGetMacro(ControllerModelsVisible, bool);
   vtkSetMacro(ControllerModelsVisible, bool);
   vtkBooleanMacro(ControllerModelsVisible, bool);
+  ///}@
 
+  ///@{
   /// If set to true then tracking references (Lighthouses) are visible in virtual reality view.
   vtkGetMacro(LighthouseModelsVisible, bool);
   vtkSetMacro(LighthouseModelsVisible, bool);
   vtkBooleanMacro(LighthouseModelsVisible, bool);
+  ///}@
 
   /// Return true if an error has occurred.
   /// "Connected" member requests connection but this method can tell if the

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -195,8 +195,10 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow()
   factory->SetMRMLApplicationLogic(appLogic);
 
   QStringList displayableManagers;
-  displayableManagers //<< "vtkMRMLCameraDisplayableManager"
-  //<< "vtkMRMLViewDisplayableManager"
+  displayableManagers
+      // Slicer
+      //<< "vtkMRMLCameraDisplayableManager" // Not supported in VR, vtkVRCamera has no MRML node counterpart
+      //<< "vtkMRMLViewDisplayableManager" // Not supported in VR, require a vtkMRMLCameraNode
       << "vtkMRMLModelDisplayableManager"
       << "vtkMRMLThreeDReformatDisplayableManager"
       << "vtkMRMLCrosshairDisplayableManager3D"


### PR DESCRIPTION
* Explain why skipping registration of View and Camera displayable managers
* Improve VirtualRealityViewNode doxygen grouping members 
* Fix comments in `vtkMRMLVirtualRealityViewNode` "CreateDefault" functions