### PR TITLE
Decouple update of transform node matrix and attribute

### DIFF
--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -495,6 +495,26 @@ void vtkMRMLVirtualRealityViewNode::CreateDefaultHMDTransformNode()
 }
 
 //----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::CreateDefaultTrackerTransformNode(const char* openVrDeviceId)
+{
+  if (openVrDeviceId == nullptr)
+  {
+    return nullptr;
+  }
+  vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = this->GetTrackerTransformNode(openVrDeviceId);
+  if (linearTransformNode == nullptr)
+  {
+    // Node wasn't found for this device, let's create one
+    linearTransformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::Take(
+                            vtkMRMLLinearTransformNode::SafeDownCast(this->GetScene()->CreateNodeByClass("vtkMRMLLinearTransformNode")));
+    linearTransformNode->SetAttribute("VirtualReality.VRDeviceID", openVrDeviceId);
+    linearTransformNode->SetName("VirtualReality.GenericTracker");
+  }
+  this->SetAndObserveTrackerTransformNode(linearTransformNode, openVrDeviceId);
+  return linearTransformNode;
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLVirtualRealityViewNode::SetControllerTransformsUpdate(bool enable)
 {
   if (enable == this->ControllerTransformsUpdate)

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -353,51 +353,51 @@ std::vector<vtkMRMLLinearTransformNode*> vtkMRMLVirtualRealityViewNode::GetTrack
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNode(const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNode(uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return nullptr;
   }
   std::stringstream ss;
-  ss << openVrDeviceId << "." << this->TrackerTransformRole;
+  ss << deviceHandle << "." << this->TrackerTransformRole;
   return vtkMRMLLinearTransformNode::SafeDownCast(
            this->GetNthNodeReference(ss.str().c_str(), 0));
 }
 
 //----------------------------------------------------------------------------
-const char* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNodeID(const char* openVrDeviceId)
+const char* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNodeID(uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return nullptr;
   }
   std::stringstream ss;
-  ss << openVrDeviceId << "." << this->TrackerTransformRole;
+  ss << deviceHandle << "." << this->TrackerTransformRole;
   return this->GetNthNodeReferenceID(ss.str().c_str(), 0);
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNodeID(const char* nodeId, uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return nullptr;
   }
   std::stringstream ss;
-  ss << openVrDeviceId << "." << this->TrackerTransformRole;
+  ss << deviceHandle << "." << this->TrackerTransformRole;
   return vtkMRMLLinearTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nodeId));
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return nullptr;
   }
   std::stringstream ss;
-  ss << openVrDeviceId << "." << this->TrackerTransformRole;
+  ss << deviceHandle << "." << this->TrackerTransformRole;
   if (node == nullptr)
   {
     return vtkMRMLLinearTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nullptr));
@@ -406,14 +406,14 @@ vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerT
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLVirtualRealityViewNode::RemoveTrackerTransformNode(const char* openVrDeviceId)
+void vtkMRMLVirtualRealityViewNode::RemoveTrackerTransformNode(uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return;
   }
   std::stringstream ss;
-  ss << openVrDeviceId << "." << this->TrackerTransformRole;
+  ss << deviceHandle << "." << this->TrackerTransformRole;
   this->RemoveNthNodeReferenceID(ss.str().c_str(), 0);
 }
 
@@ -495,22 +495,27 @@ void vtkMRMLVirtualRealityViewNode::CreateDefaultHMDTransformNode()
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::CreateDefaultTrackerTransformNode(const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::CreateDefaultTrackerTransformNode(uint32_t deviceHandle)
 {
-  if (openVrDeviceId == nullptr)
+  if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
   {
     return nullptr;
   }
-  vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = this->GetTrackerTransformNode(openVrDeviceId);
+  vtkSmartPointer<vtkMRMLLinearTransformNode> linearTransformNode = this->GetTrackerTransformNode(deviceHandle);
   if (linearTransformNode == nullptr)
   {
     // Node wasn't found for this device, let's create one
     linearTransformNode = vtkSmartPointer<vtkMRMLLinearTransformNode>::Take(
                             vtkMRMLLinearTransformNode::SafeDownCast(this->GetScene()->CreateNodeByClass("vtkMRMLLinearTransformNode")));
-    linearTransformNode->SetAttribute("VirtualReality.VRDeviceID", openVrDeviceId);
+
+    std::stringstream ss;
+    ss << deviceHandle;
+    std::string deviceHandleAsStr = ss.str();
+
+    linearTransformNode->SetAttribute("VirtualReality.VRDeviceID", deviceHandleAsStr.c_str());
     linearTransformNode->SetName("VirtualReality.GenericTracker");
   }
-  this->SetAndObserveTrackerTransformNode(linearTransformNode, openVrDeviceId);
+  this->SetAndObserveTrackerTransformNode(linearTransformNode, deviceHandle);
   return linearTransformNode;
 }
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -335,9 +335,9 @@ bool vtkMRMLVirtualRealityViewNode::SetAndObserveHMDTransformNode(vtkMRMLLinearT
 }
 
 //----------------------------------------------------------------------------
-std::vector<vtkMRMLTransformNode*> vtkMRMLVirtualRealityViewNode::GetTrackerTransformNodes()
+std::vector<vtkMRMLLinearTransformNode*> vtkMRMLVirtualRealityViewNode::GetTrackerTransformNodes()
 {
-  std::vector<vtkMRMLTransformNode*> nodes;
+  std::vector<vtkMRMLLinearTransformNode*> nodes;
 
   std::vector<std::string> roles;
   this->GetNodeReferenceRoles(roles);
@@ -353,7 +353,7 @@ std::vector<vtkMRMLTransformNode*> vtkMRMLVirtualRealityViewNode::GetTrackerTran
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLTransformNode* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNode(const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNode(const char* openVrDeviceId)
 {
   if (openVrDeviceId == nullptr)
   {
@@ -378,7 +378,7 @@ const char* vtkMRMLVirtualRealityViewNode::GetTrackerTransformNodeID(const char*
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId)
 {
   if (openVrDeviceId == nullptr)
   {
@@ -386,11 +386,11 @@ vtkMRMLTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransfo
   }
   std::stringstream ss;
   ss << openVrDeviceId << "." << this->TrackerTransformRole;
-  return vtkMRMLTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nodeId));
+  return vtkMRMLLinearTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nodeId));
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNode(vtkMRMLTransformNode* node, const char* openVrDeviceId)
+vtkMRMLLinearTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, const char* openVrDeviceId)
 {
   if (openVrDeviceId == nullptr)
   {
@@ -400,9 +400,9 @@ vtkMRMLTransformNode* vtkMRMLVirtualRealityViewNode::SetAndObserveTrackerTransfo
   ss << openVrDeviceId << "." << this->TrackerTransformRole;
   if (node == nullptr)
   {
-    return vtkMRMLTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nullptr));
+    return vtkMRMLLinearTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, nullptr));
   }
-  return vtkMRMLTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, node->GetID()));
+  return vtkMRMLLinearTransformNode::SafeDownCast(this->SetAndObserveNthNodeReferenceID(ss.str().c_str(), 0, node->GetID()));
 }
 
 //----------------------------------------------------------------------------

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -117,15 +117,15 @@ public:
   bool SetAndObserveHMDTransformNode(vtkMRMLLinearTransformNode* node);
 
   /// Get generic tracker transform node
-  std::vector<vtkMRMLTransformNode*> GetTrackerTransformNodes();
-  vtkMRMLTransformNode* GetTrackerTransformNode(const char* openVrDeviceId);
+  std::vector<vtkMRMLLinearTransformNode*> GetTrackerTransformNodes();
+  vtkMRMLLinearTransformNode* GetTrackerTransformNode(const char* openVrDeviceId);
   const char* GetTrackerTransformNodeID(const char* openVrDeviceId);
   /// Set tracker transform node.
   /// \sa GetTrackerTransformNode
-  vtkMRMLTransformNode* SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId);
   /// Set tracker transform node.
   /// \sa GetTrackerTransformNode
-  vtkMRMLTransformNode* SetAndObserveTrackerTransformNode(vtkMRMLTransformNode* node, const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, const char* openVrDeviceId);
   /// Remove a tracker transform node.
   /// \sa SetAndObserveTrackerTransformNode
   void RemoveTrackerTransformNode(const char* openVrDeviceId);

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -81,6 +81,9 @@ public:
   /// Create camera transform node if not set already.
   void CreateDefaultHMDTransformNode();
 
+  /// Create generic tracker transform node if not set already.
+  vtkMRMLLinearTransformNode* CreateDefaultTrackerTransformNode(const char* openVrDeviceId);
+
   /// Get controller node by device identifier
   vtkMRMLLinearTransformNode* GetControllerTransformNode(vtkEventDataDevice device);
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -82,7 +82,7 @@ public:
   void CreateDefaultHMDTransformNode();
 
   /// Create generic tracker transform node if not set already.
-  vtkMRMLLinearTransformNode* CreateDefaultTrackerTransformNode(const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* CreateDefaultTrackerTransformNode(uint32_t deviceHandle);
 
   /// Get controller node by device identifier
   vtkMRMLLinearTransformNode* GetControllerTransformNode(vtkEventDataDevice device);
@@ -121,17 +121,17 @@ public:
 
   /// Get generic tracker transform node
   std::vector<vtkMRMLLinearTransformNode*> GetTrackerTransformNodes();
-  vtkMRMLLinearTransformNode* GetTrackerTransformNode(const char* openVrDeviceId);
-  const char* GetTrackerTransformNodeID(const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* GetTrackerTransformNode(uint32_t deviceHandle);
+  const char* GetTrackerTransformNodeID(uint32_t deviceHandle);
   /// Set tracker transform node.
   /// \sa GetTrackerTransformNode
-  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNodeID(const char* nodeId, const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNodeID(const char* nodeId, uint32_t deviceHandle);
   /// Set tracker transform node.
   /// \sa GetTrackerTransformNode
-  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, const char* openVrDeviceId);
+  vtkMRMLLinearTransformNode* SetAndObserveTrackerTransformNode(vtkMRMLLinearTransformNode* node, uint32_t deviceHandle);
   /// Remove a tracker transform node.
   /// \sa SetAndObserveTrackerTransformNode
-  void RemoveTrackerTransformNode(const char* openVrDeviceId);
+  void RemoveTrackerTransformNode(uint32_t deviceHandle);
   /// Remove all tracker transform node.
   /// \sa SetAndObserveTrackerTransformNode
   void RemoveAllTrackerTransformNodes();

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -548,20 +548,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodesWithTrackerPoses()
     std::stringstream ss;
     ss << handle;
 
-    vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->GetTrackerTransformNode(ss.str().c_str());
-    if (node == nullptr)
-    {
-      // Node wasn't found for this device, let's create one
-      node = vtkMRMLLinearTransformNode::SafeDownCast(this->MRMLVirtualRealityViewNode->GetScene()->AddNode(vtkMRMLLinearTransformNode::New()));
-      if (node == nullptr)
-      {
-        qCritical() << Q_FUNC_INFO << ": Unable to add transform node to scene. Can't update VR tracker with ID: " << handle;
-        continue;
-      }
-      node->SetAttribute("VirtualReality.VRDeviceID", ss.str().c_str());
-      node->SetName("VirtualReality.GenericTracker");
-      this->MRMLVirtualRealityViewNode->SetAndObserveTrackerTransformNode(node, ss.str().c_str());
-    }
+    vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->CreateDefaultTrackerTransformNode(ss.str().c_str());
 
     int disabledModify = node->StartModify();
     this->updateTransformNodeFromDevice(node, vtkEventDataDevice::GenericTracker, i);

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -545,10 +545,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodesWithTrackerPoses()
   for (uint32_t i = 0; i < this->RenderWindow->GetNumberOfDeviceHandlesForDevice(vtkEventDataDevice::GenericTracker); ++i)
   {
     uint32_t handle = this->RenderWindow->GetDeviceHandleForDevice(vtkEventDataDevice::GenericTracker, i);
-    std::stringstream ss;
-    ss << handle;
-
-    vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->CreateDefaultTrackerTransformNode(ss.str().c_str());
+    vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->CreateDefaultTrackerTransformNode(handle);
 
     int disabledModify = node->StartModify();
     this->updateTransformNodeFromDevice(node, vtkEventDataDevice::GenericTracker, i);

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -604,7 +604,7 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodesWithTrackerPoses()
     std::stringstream ss;
     ss << dev;
 
-    vtkMRMLTransformNode* node = vtkMRMLTransformNode::SafeDownCast(this->MRMLVirtualRealityViewNode->GetTrackerTransformNode(ss.str().c_str()));
+    vtkMRMLLinearTransformNode* node = this->MRMLVirtualRealityViewNode->GetTrackerTransformNode(ss.str().c_str());
     if (node == nullptr)
     {
       // Node wasn't found for this device, let's create one

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -93,7 +93,10 @@ protected:
   void updateTransformNodeWithControllerPose(vtkEventDataDevice device);
   void updateTransformNodeWithHMDPose();
   void updateTransformNodesWithTrackerPoses();
-  void updateTransformNodeWithPose(vtkMRMLTransformNode* node, vr::TrackedDevicePose_t* tdPose);
+
+  void updateTransformNodeFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index=0);
+  void updateTransformNodeAttributesFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index=0);
+
   void createRenderWindow();
   void destroyRenderWindow();
 


### PR DESCRIPTION
The following changes are done anticipating subsequent commits introducing support for both `OpenVR` and `OpenXR` 

-----------

Generalize updates of node attributes to all type of devices and introduce two distinct functions:
* `updateTransformNodeFromDevice`
* `updateTransformNodeAttributesFromDevice`

All transform nodes are now consistently set with these attributes:
* `VirtualReality.<DeviceType>Active`
* `VirtualReality.<DeviceType>Connected`
* `VirtualReality.PoseValid`
* `VirtualReality.PoseStatus`
    
where `<DeviceType>` may be "HMD", "Controller" or "Tracker"

----------

Simplify introducing `CreateDefaultTrackerTransformNode` API. Similarly to HMD, left and right controllers, this commit updates the `vtkMRMLVirtualRealityViewNode` API to support creating default transform nodes associated with each generic trackers.