### PR TITLE
Add OpenXRRemoting support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,29 @@ message(STATUS "")
 message(STATUS "Setting SlicerVirtualReality_HAS_OPENXR_SUPPORT to ${SlicerVirtualReality_HAS_OPENXR_SUPPORT}${_reason}")
 message(STATUS "")
 
+# OpenXRRemoting
+set(_default OFF)
+set(_reason)
+if(NOT DEFINED SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  if(WIN32)
+    if(NOT SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+      set(_default OFF)
+      set(_reason " (OpenXR support was disabled)")
+    else()
+      set(_default ON)
+      set(_reason " (OpenXRRemoting is supported on Windows)")
+    endif()
+  else()
+    set(_default OFF)
+    set(_reason " (OpenXRRemoting is not supported on this platform)")
+  endif()
+endif()
+option(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT "Build OpenXR Remoting support" ${_default})
+mark_as_superbuild(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+message(STATUS "")
+message(STATUS "Setting SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT to ${SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT}${_reason}")
+message(STATUS "")
+
 #-----------------------------------------------------------------------------
 # SuperBuild setup
 option(${EXTENSION_NAME}_SUPERBUILD "Build ${EXTENSION_NAME} and the projects it depends on." ON)
@@ -100,6 +123,12 @@ set(SlicerVirtualReality_HAS_OPENXR_SUPPORT ${SlicerVirtualReality_HAS_OPENXR_SU
 if(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
   set(vtkRenderingOpenXR_DIR \"${vtkRenderingOpenXR_DIR}\")
   find_package(vtkRenderingOpenXR REQUIRED)
+endif()
+
+set(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT ${SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT})
+if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  set(vtkRenderingOpenXRRemoting_DIR \"${vtkRenderingOpenXRRemoting_DIR}\")
+  find_package(vtkRenderingOpenXRRemoting REQUIRED)
 endif()
 ##################################################
 ")
@@ -165,11 +194,13 @@ endif()
 #-----------------------------------------------------------------------------
 set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
 
+# vtkRenderingVR
 list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingVR_DIR};vtkRenderingVR;runtime;/")
 if(Slicer_USE_PYTHONQT)
   list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingVR_DIR};vtkRenderingVR;python;/")
 endif()
 
+# vtkRenderingOpenVR
 if(SlicerVirtualReality_HAS_OPENVR_SUPPORT)
   list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenVR_DIR};vtkRenderingOpenVR;runtime;/")
   if(Slicer_USE_PYTHONQT)
@@ -177,10 +208,19 @@ if(SlicerVirtualReality_HAS_OPENVR_SUPPORT)
   endif()
 endif()
 
+# vtkRenderingOpenXR
 if(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
   list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenXR_DIR};vtkRenderingOpenXR;runtime;/")
   if(Slicer_USE_PYTHONQT)
     list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenXR_DIR};vtkRenderingOpenXR;python;/")
+  endif()
+endif()
+
+# vtkRenderingOpenXRRemoting
+if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenXRRemoting_DIR};vtkRenderingOpenXRRemoting;runtime;/")
+  if(Slicer_USE_PYTHONQT)
+    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenXRRemoting_DIR};vtkRenderingOpenXRRemoting;python;/")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,34 @@ if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
   if(Slicer_USE_PYTHONQT)
     list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${vtkRenderingOpenXRRemoting_DIR};vtkRenderingOpenXRRemoting;python;/")
   endif()
+
+  # OpenXRRemoting: RemotingXR.json and companion files are copied or installed along side the
+  # vtkRenderingRemotingOpenXR library so that "vtkOpenXRManagerRemoteConnection::Initialize()"
+  # can locate the files and set the XR_RUNTIME_JSON env. variable
+  set(OpenXRRemoting_FILES )
+  if(WIN32)
+    set(OpenXRRemoting_FILES
+      Microsoft.Holographic.AppRemoting.OpenXr.dll
+      Microsoft.Holographic.AppRemoting.OpenXr.SU.dll
+      PerceptionDevice.dll
+      RemotingXR.json
+      )
+  endif()
+  set(_dest ${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_BIN_DIR})
+  foreach(file IN LISTS OpenXRRemoting_FILES)
+    # Copy
+    message(STATUS "Copying ${file} to ${_dest}")
+    file(COPY ${OpenXRRemoting_BIN_DIR}/${file}
+      DESTINATION ${_dest}
+      USE_SOURCE_PERMISSIONS
+      )
+    # Install
+    install(FILES ${OpenXRRemoting_BIN_DIR}/${file}
+      DESTINATION ${Slicer_INSTALL_THIRDPARTY_LIB_DIR}
+      COMPONENT RuntimeLibraries
+      )
+  endforeach()
+
 endif()
 
 set(${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS "${EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS}" CACHE STRING "List of external projects to install" FORCE)

--- a/SuperBuild/External_OpenXRRemoting.cmake
+++ b/SuperBuild/External_OpenXRRemoting.cmake
@@ -23,8 +23,8 @@ if((NOT OpenXRRemoting_BIN_DIR OR NOT OpenXRRemoting_INCLUDE_DIR)
 
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
-  set(_ver "2.9.1")
-  set(_sha256 "e8174adaf64089a0cd7cc7e21445dbe8151b57b364312eab773e5c64d9dc28b1")
+  set(_ver "2.9.3")
+  set(_sha256 "9ef533aeff9ddef40104ad0d03e1e631c314729b18690385a4a624fab2408797")
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_OpenXRRemoting.cmake
+++ b/SuperBuild/External_OpenXRRemoting.cmake
@@ -1,0 +1,74 @@
+
+set(proj OpenXRRemoting)
+
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED OpenXRRemoting_BIN_DIR AND NOT EXISTS ${OpenXRRemoting_BIN_DIR})
+  message(FATAL_ERROR "OpenXRRemoting_BIN_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+if(DEFINED OpenXRRemoting_INCLUDE_DIR AND NOT EXISTS ${OpenXRRemoting_INCLUDE_DIR})
+  message(FATAL_ERROR "OpenXRRemoting_INCLUDE_DIR variable is defined but corresponds to nonexistent path")
+endif()
+
+if((NOT OpenXRRemoting_BIN_DIR OR NOT OpenXRRemoting_INCLUDE_DIR)
+   AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  set(_ver "2.9.1")
+  set(_sha256 "e8174adaf64089a0cd7cc7e21445dbe8151b57b364312eab773e5c64d9dc28b1")
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    URL "https://www.nuget.org/api/v2/package/Microsoft.Holographic.Remoting.OpenXr/${_ver}"
+    URL_HASH "SHA256=${_sha256}"
+    SOURCE_DIR ${EP_INSTALL_DIR}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  set(OpenXRRemoting_BIN_DIR "${EP_INSTALL_DIR}/build/native/bin/x64/Desktop/")
+  set(OpenXRRemoting_INCLUDE_DIR "${EP_INSTALL_DIR}/build/native/include/openxr/")
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to build tree
+
+  # library paths
+  set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
+    ${OpenXRRemoting_BIN_DIR}
+    )
+  mark_as_superbuild(
+    VARS ${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
+    LABELS "LIBRARY_PATHS_LAUNCHER_BUILD"
+    )
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to install tree
+
+  # NA
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+ExternalProject_Message(${proj} "OpenXRRemoting_BIN_DIR:${OpenXRRemoting_BIN_DIR}")
+ExternalProject_Message(${proj} "OpenXRRemoting_INCLUDE_DIR:${OpenXRRemoting_INCLUDE_DIR}")
+
+mark_as_superbuild(
+  VARS
+    OpenXRRemoting_BIN_DIR:PATH
+    OpenXRRemoting_INCLUDE_DIR:PATH
+  )
+

--- a/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
+++ b/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
@@ -1,0 +1,118 @@
+#-----------------------------------------------------------------------------
+# Build VTK Rendering OpenXRRemoting module, pointing it to Slicer's VTK and the vtkRenderingOpenXR
+# module also built by this extension.
+
+set(proj vtkRenderingOpenXRRemoting)
+
+# Set dependency list
+set(${proj}_DEPENDS
+  vtkRenderingOpenXR
+  OpenXRRemoting
+  )
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR})
+  message(FATAL_ERROR "${proj}_DIR [${${proj}_DIR}] variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+  if(VTK_WRAP_PYTHON)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
+      -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
+      -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
+      # Required by FindPython3 CMake module used by VTK
+      -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+      -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+      -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+      -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+      -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+      -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+      )
+  endif()
+
+  if(NOT EXISTS ${VTKExternalModule_SOURCE_DIR})
+    message(FATAL_ERROR "VTKExternalModule_SOURCE_DIR [${VTKExternalModule_SOURCE_DIR}] variable is set to a nonexistent directory")
+  endif()
+
+  set(VTK_SOURCE_DIR ${VTK_DIR}/../VTK)
+  ExternalProject_Message(${proj} "VTK_SOURCE_DIR:${VTK_SOURCE_DIR}")
+
+  set(_module_subdir Rendering/OpenXRRemoting)
+  set(_module_name RenderingOpenXRRemoting)
+
+  set(EP_SOURCE_DIR ${VTK_SOURCE_DIR}/${_module_subdir})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    DOWNLOAD_COMMAND ""
+    SOURCE_DIR ${VTKExternalModule_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_COMMAND ""
+    CMAKE_CACHE_ARGS
+      # VTKExternalModule
+      -DVTK_MODULE_NAME:STRING=${_module_name}
+      -DVTK_MODULE_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
+      -DVTK_MODULE_CMAKE_MODULE_PATH:PATH=${VTK_SOURCE_DIR}/CMake
+      # vtkRenderingOpenXRRemoting
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DBUILD_TESTING:BOOL=OFF
+      -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_BIN_DIR}
+      -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_LIB_DIR}
+      -DCMAKE_INSTALL_BINDIR:STRING=${Slicer_INSTALL_THIRDPARTY_BIN_DIR}
+      -DCMAKE_INSTALL_LIBDIR:STRING=${Slicer_INSTALL_THIRDPARTY_LIB_DIR}
+      -DCMAKE_MACOSX_RPATH:BOOL=0
+      # Required to find VTK
+      -DVTK_DIR:PATH=${VTK_DIR}
+      # Required to find vtkRenderingOpenXRRemoting
+      -DvtkRenderingVR_DIR:PATH=${vtkRenderingVR_DIR}
+      -DvtkRenderingOpenXR_DIR:PATH=${vtkRenderingOpenXR_DIR}
+      # Required to find OpenXRRemoting
+      -DOpenXRRemoting_BIN_DIR:PATH=${OpenXRRemoting_BIN_DIR}
+      -DOpenXRRemoting_INCLUDE_DIR:PATH=${OpenXRRemoting_INCLUDE_DIR}
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+
+  ExternalProject_AlwaysConfigure(${proj})
+
+  set(${proj}_DIR ${EP_BINARY_DIR})
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to build tree
+
+  # pythonpath
+  set(${proj}_PYTHONPATH_LAUNCHER_BUILD
+    ${${proj}_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtkmodules
+    )
+  mark_as_superbuild(
+    VARS ${proj}_PYTHONPATH_LAUNCHER_BUILD
+    LABELS "PYTHONPATH_LAUNCHER_BUILD"
+    )
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to install tree
+
+  # NA
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+mark_as_superbuild(VARS ${proj}_DIR:PATH)
+ExternalProject_Message(${proj} "${proj}_DIR:${${proj}_DIR}")
+

--- a/SuperBuildPrerequisites.cmake
+++ b/SuperBuildPrerequisites.cmake
@@ -15,6 +15,9 @@ endif()
 if(NOT DEFINED SlicerVirtualReality_HAS_OPENXR_SUPPORT)
   message(FATAL_ERROR "SlicerVirtualReality_HAS_OPENXR_SUPPORT is not set")
 endif()
+if(NOT DEFINED SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  message(FATAL_ERROR "SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT is not set")
+endif()
 
 # Set list of dependencies to ensure the custom application bundling this
 # extension does NOT automatically collect the project list and attempt to
@@ -48,6 +51,11 @@ else()
       vtkRenderingOpenXR
       )
   endif()
+  if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+    list(APPEND SlicerVirtualReality_EXTERNAL_PROJECT_DEPENDENCIES
+      vtkRenderingOpenXRRemoting
+      )
+  endif()
 endif()
 message(STATUS "SlicerVirtualReality_EXTERNAL_PROJECT_DEPENDENCIES:${SlicerVirtualReality_EXTERNAL_PROJECT_DEPENDENCIES}")
 
@@ -58,6 +66,7 @@ if(NOT DEFINED Slicer_SOURCE_DIR)
   # - vtkRenderingVR
   # - vtkRenderingOpenVR
   # - vtkRenderingOpenXR
+  # - vtkRenderingOpenXRRemoting
   include(${SlicerVirtualReality_SOURCE_DIR}/FetchVTKExternalModule.cmake)
 
 else()
@@ -89,12 +98,18 @@ else()
   else()
     set(VTK_MODULE_ENABLE_VTK_RenderingOpenXR NO)
   endif()
+  if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+    set(VTK_MODULE_ENABLE_VTK_RenderingOpenXRRemoting YES)
+  else()
+    set(VTK_MODULE_ENABLE_VTK_RenderingOpenXRRemoting NO)
+  endif()
 
   mark_as_superbuild(
     VARS
       VTK_MODULE_ENABLE_VTK_RenderingVR:STRING
       VTK_MODULE_ENABLE_VTK_RenderingOpenVR:STRING
       VTK_MODULE_ENABLE_VTK_RenderingOpenXR:STRING
+      VTK_MODULE_ENABLE_VTK_RenderingOpenXRRemoting:STRING
     PROJECTS
       VTK
     )

--- a/VirtualReality/CMakeLists.txt
+++ b/VirtualReality/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 if(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
   find_package(vtkRenderingOpenXR REQUIRED)
 endif()
+if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  find_package(vtkRenderingOpenXRRemoting REQUIRED)
+endif()
 
 #-----------------------------------------------------------------------------
 add_subdirectory(MRML)

--- a/VirtualReality/MRML/CMakeLists.txt
+++ b/VirtualReality/MRML/CMakeLists.txt
@@ -37,6 +37,11 @@ if(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
     VTK::RenderingOpenXR
     )
 endif()
+if(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
+  list(APPEND ${KIT}_TARGET_LIBRARIES
+    VTK::RenderingOpenXRRemoting
+    )
+endif()
 
 #-----------------------------------------------------------------------------
 SlicerMacroBuildModuleMRML(

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityConfigure.h.in
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityConfigure.h.in
@@ -3,5 +3,6 @@
 
 #cmakedefine SlicerVirtualReality_HAS_OPENVR_SUPPORT
 #cmakedefine SlicerVirtualReality_HAS_OPENXR_SUPPORT
+#cmakedefine SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT
 
 #endif

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -83,6 +83,9 @@ void vtkMRMLVirtualRealityViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(hmdTransformUpdate, HMDTransformUpdate);
   vtkMRMLWriteXMLBooleanMacro(controllerModelsVisible, ControllerModelsVisible);
   vtkMRMLWriteXMLBooleanMacro(lighthouseModelsVisible, LighthouseModelsVisible);
+  // OpenXRRemoting
+  vtkMRMLWriteXMLBooleanMacro(remoting, Remoting);
+  vtkMRMLWriteXMLStdStringMacro(playerIPAddress, PlayerIPAddress);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -105,6 +108,9 @@ void vtkMRMLVirtualRealityViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(hmdTransformUpdate, HMDTransformUpdate);
   vtkMRMLReadXMLBooleanMacro(controllerModelsVisible, ControllerModelsVisible);
   vtkMRMLReadXMLBooleanMacro(lighthouseModelsVisible, LighthouseModelsVisible);
+  // OpenXRRemoting
+  vtkMRMLReadXMLBooleanMacro(remoting, Remoting);
+  vtkMRMLReadXMLStdStringMacro(playerIPAddress, PlayerIPAddress);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -131,6 +137,9 @@ void vtkMRMLVirtualRealityViewNode::Copy(vtkMRMLNode* anode)
   vtkMRMLCopyBooleanMacro(HMDTransformUpdate);
   vtkMRMLCopyBooleanMacro(ControllerModelsVisible);
   vtkMRMLCopyBooleanMacro(LighthouseModelsVisible);
+  // OpenXRRemoting
+  vtkMRMLCopyBooleanMacro(Remoting);
+  vtkMRMLCopyStringMacro(PlayerIPAddress);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -153,6 +162,9 @@ void vtkMRMLVirtualRealityViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(HMDTransformUpdate);
   vtkMRMLPrintBooleanMacro(ControllerModelsVisible);
   vtkMRMLPrintBooleanMacro(LighthouseModelsVisible);
+  // OpenXRRemoting
+  vtkMRMLPrintBooleanMacro(Remoting);
+  vtkMRMLPrintStdStringMacro(PlayerIPAddress);
   vtkMRMLPrintEndMacro();
 }
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -242,6 +242,19 @@ public:
   static int GetXRRuntimeFromString(const char* name);
   ///@}
 
+  ///@{
+  /// Get/Set if remoting is enabled.
+  vtkGetMacro(Remoting, bool);
+  vtkSetMacro(Remoting, bool);
+  vtkBooleanMacro(Remoting, bool);
+  ///@}
+
+  ///@{
+  /// OpenXR remoting IP address to connect to.
+  vtkSetMacro(PlayerIPAddress, const std::string);
+  vtkGetMacro(PlayerIPAddress, std::string);
+  ///@}
+
   /// Return true if an error has occurred.
   /// "Connected" member requests connection but this method can tell if the
   /// hardware connection has been actually successfully established.
@@ -272,6 +285,10 @@ protected:
   bool TrackerTransformUpdate;
 
   std::string LastErrorMessage;
+
+  // OpenXRRemoting
+  bool Remoting{false};
+  std::string PlayerIPAddress;
 
   vtkMRMLVirtualRealityViewNode();
   ~vtkMRMLVirtualRealityViewNode() override;

--- a/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
+++ b/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
@@ -37,13 +37,41 @@
        <widget class="QComboBox" name="XRRuntimeComboBox"/>
       </item>
       <item row="1" column="0">
+       <widget class="QLabel" name="EnableRemotingLabel">
+        <property name="text">
+         <string>Enable Remoting:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="RemotingLayout">
+        <item>
+         <widget class="QCheckBox" name="RemotingEnabledCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="PlayerIPAddressLineEdit">
+          <property name="inputMask">
+           <string>000.000.000.000</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="ConnectToHardwareLabel">
         <property name="text">
          <string>Connect to hardware:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <layout class="QHBoxLayout" name="ConnectionLayout">
         <item>
          <widget class="ctkCheckBox" name="ConnectCheckBox"/>
@@ -100,14 +128,14 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="EnableRenderingLabel">
         <property name="text">
          <string>Enable rendering:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="ctkCheckBox" name="RenderingEnabledCheckBox"/>
       </item>
      </layout>

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -90,6 +90,8 @@ public:
   double stillUpdateRate();
 
   vtkMRMLVirtualRealityViewNode::XRRuntimeType currentXRRuntime() const;
+  bool currentXRRuntimeRemotingEnabled() const;
+  std::string currentXRRuntimeRemotingIPAddress() const;
 
 public slots:
   void updateWidgetFromMRML();

--- a/VirtualReality/qSlicerVirtualRealityModule.cxx
+++ b/VirtualReality/qSlicerVirtualRealityModule.cxx
@@ -469,6 +469,16 @@ void qSlicerVirtualRealityModule::updateDefaultViewNodeFromSettings(vtkMRMLVirtu
                           settings.value("DefaultXRRuntime").toString().toUtf8().constData());
   }
   defaultViewNode->SetXRRuntime(defaultXRRuntime);
+  // Remoting
+  if (settings.contains("DefaultRemotingEnabled"))
+  {
+    defaultViewNode->SetRemoting(settings.value("DefaultRemotingEnabled").toBool());
+  }
+  // PlayerIPAddress
+  if (settings.contains("DefaultPlayerIPAddress"))
+  {
+    defaultViewNode->SetPlayerIPAddress(settings.value("DefaultPlayerIPAddress").toString().toStdString());
+  }
   settings.endGroup(); // VirtualReality
 }
 

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.h
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.h
@@ -54,6 +54,9 @@ public slots:
   void setControllerTransformsUpdate(bool);
   void setHMDTransformUpdate(bool);
   void setTrackerTransformsUpdate(bool);
+  // OpenXRRemoting
+  void setRemotingEnabled(bool);
+  void onPlayerIPAddressLineEditEditingFinished();
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
This commit adds support for OpenXR Remoting by adding the `OpenXRRemoting` and `vtkRenderingOpenXRRemoting` external projects. It also updates the view node by adding "Remoting" and "PlayerIPAddress" properties. The corresponding UI updates include a checkbox for toggling remoting and a `QLineEdit` for entering the IP address.

The macro `SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT` is added to `vtkMRMLVirtualRealityConfigure.h.in` to conditionally include code specific to OpenXR remoting.

The "Remoting" checkbox and "PlayerIPAddress" line edit are disabled if an active connection has been established.

To fix the issue of `wglDXRegisterObjectNV failed in RegisterSharedTexture()` in OpenXRRemoting, the OpenXRRemoting HelperWindow MultiSamples property is explicitly set to 0.

To ensure that no background is displayed, the background alpha/color/gradient is explicitly set when remoting is used.

The last "Remoting" and "PlayerIPAddress" properties associated with a successful hardware connection are saved to and restored from the settings.

------------

Update OpenXRRemoting from 2.9.1 to 2.9.3: This enables building the SlicerVirtualReality extension against the latest version (2.9.3) of Microsoft.Holographic.Remoting.OpenXr. This aligns SlicerVirtualReality with the corresponding version of the "Holographic Remoting Player" available on the Microsoft Store.

The update relies on VTK changes integrated into the upstream VTK project via vtk/vtk!10814. Additionally, Slicer/VTK fork branches, namely Slicer/VTK#53 for SlicerPreview and Slicer/VTK#54 for SlicerStable, have been synchronized with these changes.

For SlicerPreview, changes have been integrated in Slicer through Slicer/Slicer#7534. In the case of SlicerStable, the updated VTK fork has been manually checked out on the relevant build machines to incorporate the necessary adjustments.