### PR TITLE
COMP: Update VTKExternalModule to ensure find_dependency macro is always available

### DIFF
--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -6,7 +6,7 @@ set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/KitwareMedical/VTKExternalModule
-  GIT_TAG        50f1c5be9c7a29e9aa768dbb632fdf74d13b4361
+  GIT_TAG        37ade3c2605fc32a7c3a639fd77073a41e7ad7a8
   QUIET
   )
 message(STATUS "Remote - ${proj} [OK]")


### PR DESCRIPTION
This change is done anticipating the integration of https://github.com/KitwareMedical/SlicerVirtualReality/pull/151 adding `vtkRenderingOpenXRRemoting` requiring  https://github.com/KitwareMedical/VTKExternalModule/commit/bf0bd2b952376485213227c542ea28f87a20300e (`Update vtkmodule-config to ensure find_dependency macro is always available`) originally integrated through https://github.com/KitwareMedical/VTKExternalModule/pull/3

List of changes:

```
$ git shortlog 50f1c5be9..37ade3c26 --no-merges
Chris Harris (1):
      Add VTK_WHEEL_BUILD option

Jean-Christophe Fillion-Robin (6):
      Add support for externally building tests of a VTK modules
      Update vtkmodule-config to ensure find_dependency macro is always available
      Add SuperBuild support
      Remove redundant BUILD_TESTING option
      COMP: Support configuring install directories
      Add support for finding VTKCompileTools and passing cross-compilation variables (#7)

Patrick Avery (1):
      Update runtime install path for Windows
```