### PR TITLE
COMP: Disable OpenXR runtime build by default on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,10 @@ message(STATUS "")
 
 # OpenXR
 set(_default ON)
-set(_reason)
+if(NOT DEFINED SlicerVirtualReality_HAS_OPENXR_SUPPORT AND APPLE)
+  set(_default OFF)
+  set(_reason " (OpenXR not supported on macOS)")
+endif()
 option(SlicerVirtualReality_HAS_OPENXR_SUPPORT "Build OpenXR XR runtime" ${_default})
 mark_as_superbuild(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
 message(STATUS "")


### PR DESCRIPTION
Since attempting to build on macOS results into few errors described below, this commit sets the default value for `SlicerVirtualReality_HAS_OPENXR_SUPPORT` to `OFF`.

## macOS errors related to `OpenXR-SDK` and `vtkRenderingOpenXR`
For future reference, see https://github.com/KitwareMedical/SlicerVirtualReality/pull/150#issue-2060665294