### PR TITLE
COMP: Update VTK external projects to set python module destination

### DIFF
--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -6,7 +6,7 @@ set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/KitwareMedical/VTKExternalModule
-  GIT_TAG        37ade3c2605fc32a7c3a639fd77073a41e7ad7a8
+  GIT_TAG        3a290ec10d3e8326cd009759d87d8d219c551b47
   QUIET
   )
 message(STATUS "Remote - ${proj} [OK]")

--- a/SuperBuild/External_vtkRenderingOpenVR.cmake
+++ b/SuperBuild/External_vtkRenderingOpenVR.cmake
@@ -50,6 +50,10 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
   set(_module_subdir Rendering/OpenVR)
   set(_module_name RenderingOpenVR)
 
+  # The python module destination directory is set to `bin/Python/vtkmodules` to
+  # match the value hard-coded in "CMake/SlicerExtensionCPackBundleFixup.cmake.in"
+  set(_module_python_module_dir "${Slicer_INSTALL_THIRDPARTY_BIN_DIR}/Python/vtkmodules")
+
   set(EP_SOURCE_DIR ${VTK_SOURCE_DIR}/${_module_subdir})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -68,6 +72,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DVTK_MODULE_NAME:STRING=${_module_name}
       -DVTK_MODULE_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
       -DVTK_MODULE_CMAKE_MODULE_PATH:PATH=${VTK_SOURCE_DIR}/CMake
+      -DVTK_MODULE_PYTHON_MODULE_DESTINATION:STRING=${_module_python_module_dir}/.. # "vtkmodules" is implicitly appended
       -DOpenVR_FIND_PACKAGE_VARS:STRING=OpenVR_INCLUDE_DIR;OpenVR_LIBRARY
       # vtkRenderingOpenVR
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
@@ -103,7 +108,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   # pythonpath
   set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-    ${${proj}_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtkmodules
+    ${${proj}_DIR}/${_module_python_module_dir}
     )
   mark_as_superbuild(
     VARS ${proj}_PYTHONPATH_LAUNCHER_BUILD

--- a/SuperBuild/External_vtkRenderingOpenXR.cmake
+++ b/SuperBuild/External_vtkRenderingOpenXR.cmake
@@ -50,6 +50,10 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
   set(_module_subdir Rendering/OpenXR)
   set(_module_name RenderingOpenXR)
 
+  # The python module destination directory is set to `bin/Python/vtkmodules` to
+  # match the value hard-coded in "CMake/SlicerExtensionCPackBundleFixup.cmake.in"
+  set(_module_python_module_dir "${Slicer_INSTALL_THIRDPARTY_BIN_DIR}/Python/vtkmodules")
+
   set(EP_SOURCE_DIR ${VTK_SOURCE_DIR}/${_module_subdir})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -68,6 +72,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DVTK_MODULE_NAME:STRING=${_module_name}
       -DVTK_MODULE_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
       -DVTK_MODULE_CMAKE_MODULE_PATH:PATH=${VTK_SOURCE_DIR}/CMake
+      -DVTK_MODULE_PYTHON_MODULE_DESTINATION:STRING=${_module_python_module_dir}/.. # "vtkmodules" is implicitly appended
       -DOpenXR_FIND_PACKAGE_VARS:STRING=
       # vtkRenderingOpenXR
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
@@ -101,7 +106,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   # pythonpath
   set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-    ${${proj}_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtkmodules
+    ${${proj}_DIR}/${_module_python_module_dir}
     )
   mark_as_superbuild(
     VARS ${proj}_PYTHONPATH_LAUNCHER_BUILD

--- a/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
+++ b/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
@@ -50,6 +50,10 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
   set(_module_subdir Rendering/OpenXRRemoting)
   set(_module_name RenderingOpenXRRemoting)
 
+  # The python module destination directory is set to `bin/Python/vtkmodules` to
+  # match the value hard-coded in "CMake/SlicerExtensionCPackBundleFixup.cmake.in"
+  set(_module_python_module_dir "${Slicer_INSTALL_THIRDPARTY_BIN_DIR}/Python/vtkmodules")
+
   set(EP_SOURCE_DIR ${VTK_SOURCE_DIR}/${_module_subdir})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -64,6 +68,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DVTK_MODULE_NAME:STRING=${_module_name}
       -DVTK_MODULE_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
       -DVTK_MODULE_CMAKE_MODULE_PATH:PATH=${VTK_SOURCE_DIR}/CMake
+      -DVTK_MODULE_PYTHON_MODULE_DESTINATION:STRING=${_module_python_module_dir}/.. # "vtkmodules" is implicitly appended
       # vtkRenderingOpenXRRemoting
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
@@ -97,7 +102,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   # pythonpath
   set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-    ${${proj}_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtkmodules
+    ${${proj}_DIR}/${_module_python_module_dir}
     )
   mark_as_superbuild(
     VARS ${proj}_PYTHONPATH_LAUNCHER_BUILD

--- a/SuperBuild/External_vtkRenderingVR.cmake
+++ b/SuperBuild/External_vtkRenderingVR.cmake
@@ -48,6 +48,10 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
   set(_module_subdir Rendering/VR)
   set(_module_name RenderingVR)
 
+  # The python module destination directory is set to `bin/Python/vtkmodules` to
+  # match the value hard-coded in "CMake/SlicerExtensionCPackBundleFixup.cmake.in"
+  set(_module_python_module_dir "${Slicer_INSTALL_THIRDPARTY_BIN_DIR}/Python/vtkmodules")
+
   set(EP_SOURCE_DIR ${VTK_SOURCE_DIR}/${_module_subdir})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
@@ -62,6 +66,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DVTK_MODULE_NAME:STRING=${_module_name}
       -DVTK_MODULE_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
       -DVTK_MODULE_CMAKE_MODULE_PATH:PATH=${VTK_SOURCE_DIR}/CMake
+      -DVTK_MODULE_PYTHON_MODULE_DESTINATION:STRING=${_module_python_module_dir}/.. # "vtkmodules" is implicitly appended
       # vtkRenderingVR
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
@@ -89,7 +94,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   # pythonpath
   set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-    ${${proj}_DIR}/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtkmodules
+    ${${proj}_DIR}/${_module_python_module_dir}
     )
   mark_as_superbuild(
     VARS ${proj}_PYTHONPATH_LAUNCHER_BUILD


### PR DESCRIPTION
This updates VTKExternalModule and set the Python module install destination install the VTK modules similarly to the location in Slicer core, it is also done anticipating the support for packaging VTK modules on macOS.

List of VTKExternalModule changes:

```
$ git shortlog 37ade3c26..3a290ec10 --no-merges
Jean-Christophe Fillion-Robin (1):
      Support customizing Python module install destination
```

Related:
* https://github.com/KitwareMedical/VTKExternalModule/pull/8