### PR TITLE
COMP: Clear CMAKE_INSTALL_NAME_TOOL to fix packaging of VTK modules on macOS

### DIFF
--- a/SuperBuild/External_vtkRenderingOpenVR.cmake
+++ b/SuperBuild/External_vtkRenderingOpenVR.cmake
@@ -40,6 +40,15 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(APPLE)
+    # Clearing CMAKE_INSTALL_NAME_TOOL is crucial to ensure that the installed
+    # VTK libraries have their ID associated with a full path. This step is
+    # required for the fix-up process to work as expected.
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_INSTALL_NAME_TOOL:FILEPATH=
+      )
+  endif()
+
   if(NOT EXISTS ${VTKExternalModule_SOURCE_DIR})
     message(FATAL_ERROR "VTKExternalModule_SOURCE_DIR [${VTKExternalModule_SOURCE_DIR}] variable is set to a nonexistent directory")
   endif()

--- a/SuperBuild/External_vtkRenderingOpenXR.cmake
+++ b/SuperBuild/External_vtkRenderingOpenXR.cmake
@@ -40,6 +40,15 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(APPLE)
+    # Clearing CMAKE_INSTALL_NAME_TOOL is crucial to ensure that the installed
+    # VTK libraries have their ID associated with a full path. This step is
+    # required for the fix-up process to work as expected.
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_INSTALL_NAME_TOOL:FILEPATH=
+      )
+  endif()
+
   if(NOT EXISTS ${VTKExternalModule_SOURCE_DIR})
     message(FATAL_ERROR "VTKExternalModule_SOURCE_DIR [${VTKExternalModule_SOURCE_DIR}] variable is set to a nonexistent directory")
   endif()

--- a/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
+++ b/SuperBuild/External_vtkRenderingOpenXRRemoting.cmake
@@ -40,6 +40,15 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(APPLE)
+    # Clearing CMAKE_INSTALL_NAME_TOOL is crucial to ensure that the installed
+    # VTK libraries have their ID associated with a full path. This step is
+    # required for the fix-up process to work as expected.
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_INSTALL_NAME_TOOL:FILEPATH=
+      )
+  endif()
+
   if(NOT EXISTS ${VTKExternalModule_SOURCE_DIR})
     message(FATAL_ERROR "VTKExternalModule_SOURCE_DIR [${VTKExternalModule_SOURCE_DIR}] variable is set to a nonexistent directory")
   endif()

--- a/SuperBuild/External_vtkRenderingVR.cmake
+++ b/SuperBuild/External_vtkRenderingVR.cmake
@@ -38,6 +38,15 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(APPLE)
+    # Clearing CMAKE_INSTALL_NAME_TOOL is crucial to ensure that the installed
+    # VTK libraries have their ID associated with a full path. This step is
+    # required for the fix-up process to work as expected.
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DCMAKE_INSTALL_NAME_TOOL:FILEPATH=
+      )
+  endif()
+
   if(NOT EXISTS ${VTKExternalModule_SOURCE_DIR})
     message(FATAL_ERROR "VTKExternalModule_SOURCE_DIR [${VTKExternalModule_SOURCE_DIR}] variable is set to a nonexistent directory")
   endif()


### PR DESCRIPTION
Clearing `CMAKE_INSTALL_NAME_TOOL` is crucial to ensure that the installed VTK libraries have their ID associated with a full path. This step is required for the fix-up process to work as expected.

Follow-up of these pull requests:
* https://github.com/Slicer/Slicer/pull/7537
* https://github.com/Slicer/Slicer/pull/7540