### PR TITLE
BUG: Support updated Slicer displayable manager implementation

### DIFF
--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -27,8 +27,7 @@
 // For:
 //  - Slicer_VERSION_MAJOR
 //  - Slicer_VERSION_MINOR
-//  - Slicer_REVISION
-#include <vtkSlicerVersionConfigure.h>
+#include <vtkSlicerVersionConfigureMinimal.h>
 
 // VR Logic includes
 #include "vtkSlicerVirtualRealityLogic.h"
@@ -336,7 +335,7 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
       << "vtkMRMLMarkupsDisplayableManager"
       << "vtkMRMLSegmentationsDisplayableManager3D"
       << "vtkMRMLTransformsDisplayableManager3D"
-#if (Slicer_VERSION_MAJOR >= 5 && Slicer_VERSION_MINOR >= 7 && Slicer_REVISION >= 32721)
+#if (Slicer_VERSION_MAJOR >= 5 && Slicer_VERSION_MINOR >= 7)
       << "vtkMRMLLinearTransformsDisplayableManager"
 #else
       << "vtkMRMLLinearTransformsDisplayableManager3D"

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -24,6 +24,12 @@
 //  - SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT
 #include "vtkMRMLVirtualRealityConfigure.h"
 
+// For:
+//  - Slicer_VERSION_MAJOR
+//  - Slicer_VERSION_MINOR
+//  - Slicer_REVISION
+#include <vtkSlicerVersionConfigure.h>
+
 // VR Logic includes
 #include "vtkSlicerVirtualRealityLogic.h"
 
@@ -330,7 +336,11 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
       << "vtkMRMLMarkupsDisplayableManager"
       << "vtkMRMLSegmentationsDisplayableManager3D"
       << "vtkMRMLTransformsDisplayableManager3D"
+#if (Slicer_VERSION_MAJOR >= 5 && Slicer_VERSION_MINOR >= 7 && Slicer_REVISION >= 32721)
+      << "vtkMRMLLinearTransformsDisplayableManager"
+#else
       << "vtkMRMLLinearTransformsDisplayableManager3D"
+#endif
       << "vtkMRMLVolumeRenderingDisplayableManager"
       ;
   foreach (const QString& displayableManager, displayableManagers)


### PR DESCRIPTION
Conditionally register the transform displayable manager to account for changes introduced in Slicer/Slicer@158d74bdf9 (`ENH: Clean up vtkMRMLLinearTransformsDisplayableManager implementation`, 2024-02-16)

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7590