### PR TITLE
DOC: Update README and DeveloperGuide to document OpenXR backend support

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -1,10 +1,8 @@
-Information for developers
-==========================
+# Information for developers
 
 This Slicer extension is in active development. The API may change from version to version without notice.
 
-Build instructions
-------------------
+## Build instructions
 
 - Build the extension against the newly built Slicer with Qt5 and VTK9 enabled.
 - To start Slicer from a build tree and ensure the extension is properly loaded, considering using the ``--launcher-additional-settings`` option:
@@ -21,8 +19,7 @@ Alternatively, to avoid the need to specify additional command-line parameters, 
 
 Note that specifying the top-level build directory of the extension ensures that Slicer find all types of modules.
 
-Useful Python Snippets
-----------------------
+## Useful Python Snippets
 
 Activate virtual reality view:
 

--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -4,20 +4,79 @@ This Slicer extension is in active development. The API may change from version 
 
 ## Build instructions
 
-- Build the extension against the newly built Slicer with Qt5 and VTK9 enabled.
-- To start Slicer from a build tree and ensure the extension is properly loaded, considering using the ``--launcher-additional-settings`` option:
+- Build the extension against the newly built Slicer.
+- To start Slicer from a build tree and ensure the extension is properly loaded, consider running the `SlicerWithVirtualReality` launcher. For more details, see [here](https://slicer.readthedocs.io/en/latest/developer_guide/extensions.html#run-slicer-with-your-custom-modules).
 
-   ```
-   ./Slicer.exe  --launcher-additional-settings C:\path\to\SlicerVirtualReality-build\inner-build\AdditionalLauncherSettings.ini --additional-module-paths C:\path\to\SlicerVirtualReality-build\inner-build\
-   ```
+## Mapping of Controller Action to VTK event
 
-Alternatively, to avoid the need to specify additional command-line parameters, virtual reality extension can be set up in Slicer by:
-- Copy these files to (SlicerVirtualReality-binary)\inner-build\lib\Slicer-4.9\qt-loadable-modules\Release:
-  - (SlicerVirtualReality-binary)\bin\Release\vtkRenderingOpenVR-9.0.dll
-  - (SlicerVirtualReality-binary)\OpenVR\bin\win64\openvr_api.dll
-- Add (SlicerVirtualReality-binary)\inner-build\lib\Slicer-4.9\qt-loadable-modules\Release folder to additional module paths in Slicer application settings.
+The mapping process consists of two main steps:
 
-Note that specifying the top-level build directory of the extension ensures that Slicer find all types of modules.
+1. Parsing the `vtk_open<vr|xr>_actions.json` action manifest file to link controller-specific interaction paths with generic event paths. This file references controller-specific binding files, usually named `vtk_open<vr|xr>_binding_<vendor_name>.json`, where each controller interaction path is associated with a VTK-specific event path.
+
+2. Assigning a VTK event path to either a VTK event or a `std::function`. This association of a VTK event path involving a single controller with a VTK event is carried out in `vtkOpen<VR|XR>InteractorStyle::SetupActions()`.
+
+### Action Manifest File
+
+The controller interaction paths are specific to each backend:
+
+* For OpenVR: Refer to the [List of common controller types](https://github.com/ValveSoftware/openvr/wiki/List-of-common-controller-types) and the [SteamVR Input Guide](https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/blob/master/docs/SteamVRInputGuide.md).
+* For OpenXR: Refer to the [Reserved Paths](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#semantic-path-reserved) and the [Interaction Profile Paths](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#semantic-path-interaction-profiles).
+
+As of [Slicer@c7fe8657c](https://github.com/Slicer/Slicer/commit/c7fe8657c6a4bc0666685349b3222ff3c1b4fa02), the provided `vtk_open<vr|xr>_actions.json` and `vtk_open<vr|xr>_binding_<vendor_name>.json` files in the `vtkRenderingOpenVR` and `vtkRenderingOpenXR` VTK modules are as follow:
+
+|                                 | OpenVR                                           | OpenXR                                                   |
+| ------------------------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| Action manifest                 | [url][vtk_openvr_actions_json_url]               | [url][vtk_openxr_actions_json_url]                       |
+| - HP Motion Controller          | [url][vtk_openvr_binding_hpmotioncontroller_url] | [url][vtk_openxr_binding_hp_mixed_reality_url]           |
+| - HTC Vive Controller           | [url][vtk_openvr_binding_vive_controller_url]    | [url][vtk_openxr_binding_htc_vive_controller_url]        |
+| - Microsoft Hand Interaction    |                                                  | [url][vtk_openxr_binding_microsoft_hand_interaction_url] |
+| - Oculus Touch                  | [url][vtk_openvr_binding_oculus_touch_url]       | [url][vtk_openxr_binding_oculus_touch_url]               |
+| - Valve Knuckles                | [url][vtk_openvr_binding_knuckles_url]           | [url][vtk_openxr_binding_knuckles_url]                   |
+| - Khronos Simple Controller[^1] |                                                  | [url][vtk_openxr_binding_khr_simple_url]                 |
+
+[^1]: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_khronos_simple_controller_profile
+
+These files serve as essential references for mapping controller actions to VTK events.
+
+<!-- vtkRenderingOpenVR -->
+[vtk_openvr_actions_json_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenVR/vtk_openvr_actions.json
+[vtk_openvr_binding_hpmotioncontroller_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenVR/vtk_openvr_binding_hpmotioncontroller.json
+[vtk_openvr_binding_vive_controller_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenVR/vtk_openvr_binding_vive_controller.json
+[vtk_openvr_binding_knuckles_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenVR/vtk_openvr_binding_knuckles.json
+[vtk_openvr_binding_oculus_touch_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenVR/vtk_openvr_binding_oculus_touch.json
+
+<!-- vtkRenderingOpenXR -->
+[vtk_openxr_actions_json_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_actions.json
+[vtk_openxr_binding_hp_mixed_reality_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_hp_mixed_reality.json
+[vtk_openxr_binding_htc_vive_controller_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_htc_vive_controller.json
+[vtk_openxr_binding_microsoft_hand_interaction_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_microsoft_hand_interaction.json
+[vtk_openxr_binding_oculus_touch_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_oculus_touch_controller.json
+[vtk_openxr_binding_knuckles_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_knuckles.json
+[vtk_openxr_binding_khr_simple_url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtk_openxr_binding_khr_simple_controller.json
+
+### Mapping of VTK event path
+
+The association of VTK event paths to VTK events hardcoded in each VTK modules is as follow:
+
+* For OpenVR, refer to [vtkOpenVRInteractorStyle::SetupActions()][vtkOpenVRInteractorStyle-url]
+* For OpenXR, refer to [vtkOpenXRInteractorStyle::SetupActions()][vtkOpenXRInteractorStyle-url]
+
+[vtkOpenVRInteractorStyle-url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtkOpenVRInteractorStyle.cxx
+[vtkOpenXRInteractorStyle-url]: https://github.com/Slicer/VTK/blob/slicer-v9.2.20230607-1ff325c54-2/Rendering/OpenXR/vtkOpenXRInteractorStyle.cxx
+
+### Complex Gesture Support
+
+Recognition of complex gesture events commences when the two controller buttons mapped to the ComplexGesture action are pressed.
+
+The SlicerVirtualReality implements its own heuristic by specializing the `HandleComplexGestureEvents()` and `RecognizeComplexGesture()` in the [vtkVirtualRealityComplexGestureRecognizer][vtkVirtualRealityComplexGestureRecognizer-url]  class.
+
+[vtkVirtualRealityComplexGestureRecognizer-url]: https://github.com/KitwareMedical/SlicerVirtualReality/blob/master/VirtualReality/MRMLDM/vtkVirtualRealityComplexGestureRecognizer.cxx
+
+Limitations:
+
+* The selected controller buttons are exclusively mapped to the ComplexGesture action and cannot be associated with a regular action.
+
+* To workaround an OpenVR specific [limitation](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10778), each button expected to be involved in the complex gesture needs to be respectively associated with `/actions/vtk/in/ComplexGestureAction` and `/actions/vtk/in/ComplexGestureAction_Event2`.
 
 ## Useful Python Snippets
 
@@ -28,20 +87,14 @@ Activate virtual reality view:
 import logging
 import slicer
 
-def isVRInitialized():
-    """Determine if VR has been initialized
-    """
+def isXRBackendInitialized():
+    """Determine if XR backend has been initialized."""
     vrLogic = slicer.modules.virtualreality.logic()
-    if (vrLogic is None
-        or vrLogic.GetVirtualRealityViewNode() is None
-        or not vrLogic.GetVirtualRealityViewNode().GetVisibility()
-        or not vrLogic.GetVirtualRealityViewNode().GetActive()):
-        return False
-    return True
+    return vrLogic.GetVirtualRealityActive() if vrLogic else False
 
 def vrCamera():
     # Get VR module widget
-    if not isVRInitialized():
+    if not isXRBackendInitialized():
         return None
     # Get VR camera
     vrViewWidget = slicer.modules.virtualreality.viewWidget()
@@ -54,15 +107,14 @@ def vrCamera():
     return rendererCollection.GetItemAsObject(0).GetActiveCamera()
 
 
-assert isVRInitialized() is False
+assert isXRBackendInitialized() is False
 assert vrCamera() is None
 
 vrLogic = slicer.modules.virtualreality.logic()
 vrLogic.SetVirtualRealityActive(True)
 
-assert isVRInitialized() is True
+assert isXRBackendInitialized() is True
 assert vrCamera() is not None
-
 
 ```
 
@@ -85,3 +137,9 @@ nodeLocked.SetSelectable(0)
 nodeMovable.SetSelectable(1)
 
 ```
+
+## Related VTK modules
+
+* [VTK::RenderingOpenXR](https://docs.vtk.org/en/latest/modules/vtk-modules/Rendering/OpenXR/README.html)
+* [VTK::RenderingOpenXRRemoting](https://docs.vtk.org/en/latest/modules/vtk-modules/Rendering/OpenXRRemoting/README.html)
+* [VTK::RenderingOpenVR](https://docs.vtk.org/en/latest/modules/vtk-modules/Rendering/OpenVR/README.html)

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ The extension works with all OpenVR-compatible headsets, such as [HTC Vive](#set
 
 ## Features
 
-Features include:
-- View all content of any of the 3D viewers in Slicer, anytime, by a single click.
-- Show volumes as 2D image slices or volume rendering, render surfaces, points, etc.
-- View any 4D data sets, using any rendering technique (including volume rendering) - provided by Sequences extension
-- Align the headset's view to match viewpoint of the selected 3D view in Slicer
-- Fly around using the touchpad of the right controller: direction is specified by orientation of the controller; speed is determined by the position of the finger on the touchpad (touch at the top to fly forward, touch at the bottom to fly backward).
-- Grab and reposition objects using the grab button on the controller.
-- Translate, rotate, scale the world (all objects) by pressing grab buttons on both controllers at the same time.
-- Advanced volume rendering performance tuning: available in Virtual Reality module, to find good balance between image quality and refresh rate.
-- Make position of controllers available as transforms in the Slicer scene. These transforms can be used in custom modules to reslice volumes (using Volume Reslice Driver module in SlicerIGT extension) or transform any nodes in the scene.
+Key features:
 
-Feature set of the extension is continuously improved. You can give us feedback and propose ideas for improvements by submitting them on the [issue tracker](https://github.com/KitwareMedical/SlicerVirtualReality/issues).
+- View all content of any 3D viewer in Slicer with a single click.
+- Display volumes as 2D image slices or volume renderings, render surfaces, points, etc.
+- Visualize any 4D datasets using various rendering techniques (including volume rendering) provided by the Sequences extension.
+- Align the headset's view to match the viewpoint of the selected 3D view in Slicer.
+- Fly around using the touchpad of the right controller: direction is specified by orientation of the controller; speed is determined by the position of the finger on the touchpad (touch at the top to fly forward, touch at the bottom to fly backward).
+- Grab and reposition objects using the controller's grab button.
+- Translate, rotate, and scale the entire scene by pressing grab buttons on both controllers simultaneously.
+- Advanced volume rendering performance tuning available in the Virtual Reality module to balance image quality and refresh rate.
+- Make controller positions available as transforms in the Slicer scene. These transforms can be used in custom modules to reslice volumes (using Volume Reslice Driver module in SlicerIGT extension) or transform any nodes in the scene.
+
+Continuous improvements are made to the feature set. Feedback and ideas for improvement can be submitted via the [issue tracker](https://github.com/KitwareMedical/SlicerVirtualReality/issues).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-SlicerVirtualReality
-====================
+# SlicerVirtualReality
 
 Extension for 3D slicer that enables user to interact with the 3D scene using virtual reality.
 
@@ -8,6 +7,8 @@ Extension for 3D slicer that enables user to interact with the 3D scene using vi
 The extension works with all OpenVR-compatible headsets, such as [HTC Vive](#setup-htc-vive), all [Windows Mixed Reality headsets](#setup-windows-mixed-reality) (by Acer, Lenovo, HP, etc.), and with [Oculus Rift](#setup-oculus-rift). See the YouTube video below or this [Kitware blog post](https://blog.kitware.com/slicervirtualreality/) for some more background and application examples.
 
 [![Demo: Pedicle screw insertion in virtual reality using Slicer](https://img.youtube.com/vi/F_UBoE4FaoY/0.jpg)](https://www.youtube.com/watch?v=F_UBoE4FaoY)
+
+## Features
 
 Features include:
 - View all content of any of the 3D viewers in Slicer, anytime, by a single click.
@@ -21,9 +22,6 @@ Features include:
 - Make position of controllers available as transforms in the Slicer scene. These transforms can be used in custom modules to reslice volumes (using Volume Reslice Driver module in SlicerIGT extension) or transform any nodes in the scene.
 
 Feature set of the extension is continuously improved. You can give us feedback and propose ideas for improvements by submitting them on the [issue tracker](https://github.com/KitwareMedical/SlicerVirtualReality/issues).
-
-Usage
------
 
 ## Setup
 
@@ -72,10 +70,10 @@ Controls:
 - Touchpad forward: fly forward
 - Touchpad backwad: fly backward
 
-Notes:
-- Flying direction is specified by the orientation of the controller.
-- Speed is proportional to distance of the fingertip from the touchpad center.
-- Maximum speed is configurable in Virtual Reality module.
+> [!NOTE]
+> - Flying direction is specified by the orientation of the controller.
+> - Speed is proportional to distance of the fingertip from the touchpad center.
+> - Maximum speed is configurable in Virtual Reality module.
 
 ### Transform entire scene
 
@@ -86,9 +84,9 @@ Controls: while keeping grip button depressed on both controllers
 - Translate controllers in parallel up/down/left/right/forward/backward: translate the entire scene
 - Pivot controllers around: rotate the entire scene
 
-Notes:
-- Object positions in the scene are not modified.
-- Controllers must be outside of all selectable objects when grip buttons are pressed.
+> [!NOTE]
+> - Object positions in the scene are not modified.
+> - Controllers must be outside of all selectable objects when grip buttons are pressed.
 
 ### Transform objects
 
@@ -99,12 +97,12 @@ Controls: press grip button when a controller is inside a selectable object
 - Translate controllers in parallel up/down/left/right/forward/backward: translate all objects
 - Move controller
 
-Notes:
-- When you grab and move object, a parent transform is automatically created for it (if it has not been under a transform already) and that transform is modified.
-- To move a group of objects together, assign the same parent transform to them. You can do that in _Data_ module's _Transform hierarchy_ tab by drag-and-dropping objects under the same transform (or by double-clicking in the _Applied Transform_ column in  _Data_ module's _Transform hierarchy_ tab and selecting a transform; or by selecting a transform in _Transforms_ module and applying it to all the nodes that must move together).
-- Either left or right controller can be used to grab an object. Each controller can be used to grab an object and move independently.
-- By default all objects are selectable. An object can be made non-selectable (thus non-movable) in Data module / Subject hierarchy tab, right-clicking on the node and unchecking "Toggle Selectable".
-- Moving of segmentation nodes is slow. If you want to move segmentations using controllers then export them to model nodes (in _Data_ module, right-click on the segmentation node and choose _Export visible segments to models_) and transform the model nodes.
+> [!NOTE]
+> - When you grab and move object, a parent transform is automatically created for it (if it has not been under a transform already) and that transform is modified.
+> - To move a group of objects together, assign the same parent transform to them. You can do that in _Data_ module's _Transform hierarchy_ tab by drag-and-dropping objects under the same transform (or by double-clicking in the _Applied Transform_ column in  _Data_ module's _Transform hierarchy_ tab and selecting a transform; or by selecting a transform in _Transforms_ module and applying it to all the nodes that must move together).
+> - Either left or right controller can be used to grab an object. Each controller can be used to grab an object and move independently.
+> - By default all objects are selectable. An object can be made non-selectable (thus non-movable) in Data module / Subject hierarchy tab, right-clicking on the node and unchecking "Toggle Selectable".
+> - Moving of segmentation nodes is slow. If you want to move segmentations using controllers then export them to model nodes (in _Data_ module, right-click on the segmentation node and choose _Export visible segments to models_) and transform the model nodes.
 
 ## Other features
 
@@ -167,26 +165,22 @@ If you are certain that you have found a software bug and no similar issue has b
 
 Please do not use "VR" acronym (you can spell out "virtual reality" instead), because "VR" may mean "volume rendering" just as well as "virtual reality" - you can even do volume rendering in virtual reality in Slicer - and so it becomes confusing very quickly.
 
-For developers
---------------
+## For developers
 
 Information for developers is available in the [Developer Guide](DeveloperGuide.md).
 
-Contributors
-------------
+## Contributors
 
 Contributors include:
 - Kitware: Jean-Christophe Fillion-Robin, Jean-Baptiste Vimort
 - PerkLab (Queen's University): Csaba Pinter, Andras Lasso
 - VASST Lab (Robarts Research Insitute): Adam Rankin
 
-How to cite
------------
+## How to cite
 
 Pinter, C., Lasso, A., Choueib, S., Asselin, M., Fillion-Robin, J. C., Vimort, J. B., Martin, K., Jolley, M. A. & Fichtinger, G. (2020). SlicerVR for Medical Intervention Training and Planning in Immersive Virtual Reality. IEEE Transactions on Medical Robotics and Bionics, vol. 2, no. 2, pp. 108-117, May 2020, doi: 10.1109/TMRB.2020.2983199
 
-License
--------
+## License
 
 It is covered by the Apache License, Version 2.0:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # SlicerVirtualReality
 
-Extension for 3D slicer that enables user to interact with the 3D scene using virtual reality.
+Extension for 3D Slicer enabling interaction with the 3D scene through virtual reality (VR) or augmented reality (AR).
 
-![](SlicerVirtualReality.png)
+The extension works with all OpenVR-compatible and OpenXR-compatible virtual reality headsets, such as [HTC Vive](#setup-htc-vive), all [Windows Mixed Reality headsets](#setup-windows-mixed-reality) (by Acer, Lenovo, HP, etc.) and with [Meta Quest](#setup-meta-quest) or [Oculus Rift](#setup-oculus-rift). The extension also supports the [HoloLens 2](#setup-hololens-2) augmented reality headset.
 
-The extension works with all OpenVR-compatible headsets, such as [HTC Vive](#setup-htc-vive), all [Windows Mixed Reality headsets](#setup-windows-mixed-reality) (by Acer, Lenovo, HP, etc.), and with [Oculus Rift](#setup-oculus-rift). See the YouTube video below or this [Kitware blog post](https://blog.kitware.com/slicervirtualreality/) for some more background and application examples.
+![SlicerVirtualReality Logo](SlicerVirtualReality.png)
+
+See the YouTube video below or the [Kitware blog post](https://blog.kitware.com/slicervirtualreality/) for some more background and application examples.
 
 [![Demo: Pedicle screw insertion in virtual reality using Slicer](https://img.youtube.com/vi/F_UBoE4FaoY/0.jpg)](https://www.youtube.com/watch?v=F_UBoE4FaoY)
 
@@ -26,36 +28,105 @@ Continuous improvements are made to the feature set. Feedback and ideas for impr
 
 ## Setup
 
-**Platform support:** Currently the extension only works on Windows computers. Linux support is experimental: [Steam VR has limited support on linux](https://github.com/ValveSoftware/SteamVR-for-Linux/blob/master/README.md) and the Slicer extension is built for Linux but not tested. The extension is not available on macOS, as currently there are no virtual reality headsets available for macOS. If you wish to use Virtual Reality extension on Linux or macOS and you have virtual reality capable hardware and Steam VR works well on your computer then add a comment in the issue tracker ([macOS](https://github.com/KitwareMedical/SlicerVirtualReality/issues/3) / [Linux](https://github.com/KitwareMedical/SlicerVirtualReality/issues/57)).
+The extension supports virtual reality (VR) through both OpenXR and OpenVR backends. Augmented reality (AR) support is available by selecting the OpenXR backend and enabling remoting.
 
-**Configuring graphics:** If both integrated display card and high-performance GPU are available in a system (typically this is the case on laptops with NVidia GPUs), then configure the graphics card application settings to use high-performance GPU for `SlicerApp-real.exe` (it is not necessary to use high-performance GPU for the launcher, `Slicer.exe`).
+**Platform support:** Currently, the extension only functions on Windows computers. Linux support is experimental and untested due to the lack of official OpenXR runtimes and [limited SteamVR support on Linux](https://github.com/ValveSoftware/SteamVR-for-Linux/blob/master/README.md). The extension is available on macOS but lacks backend support due to Apple's lack of OpenXR support for the Vision Pro.
+
+|         | OpenXR             |  OpenVR            |
+| ------- | ------------------ | ------------------ |
+| Windows | :white_check_mark: | :white_check_mark: |
+| Linux   | :x:                | :x:                |
+| macOS   | :x:                | :x:                |
+
+If you wish to use Virtual Reality extension on Linux or macOS and you have virtual or augmented reality capable hardware working well on your computer through either an OpenXR runtime or an OpenVR runtime (e.g Steam VR) then add a comment in the issue tracker ([macOS](https://github.com/KitwareMedical/SlicerVirtualReality/issues/3) / [Linux](https://github.com/KitwareMedical/SlicerVirtualReality/issues/57)).
+
+**Configuring graphics:** On systems with both integrated display card and high-performance GPU (typically this is the case on laptops with NVidia GPUs), configure the graphics card application settings to use high-performance GPU for `SlicerApp-real.exe` (it is not necessary to use high-performance GPU for the launcher, `Slicer.exe`).
+
+**Generic tracker support:** Currently, generic trackers are only supported using the OpenVR backend. See issue [#171](https://github.com/KitwareMedical/SlicerVirtualReality/issues/171).
 
 <a name="setup-htc-vive" ></a>
 
 ### How to set up my HTC Vive headset
 
-- Install [Steam](http://store.steampowered.com/about/) and [SteamVR](https://store.steampowered.com/steamvr) and set up your headset (you should be able to see SteanVR home application running in your headset).
-- Install Slicer and SlicerVirtualReality extension.
-- To see content of content of the 3D view in your headset: click "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the toolbar in Slicer.
+- Install [VIVESetup][VIVESetup-link] and set up your headset.
+- Install Slicer and the SlicerVirtualReality extension.
+- To view content of the selected 3D view in your headset, click on the "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the Slicer toolbar.
+
+[VIVESetup-link]: https://www.vive.com/us/setup/pc-vr/
+
+By default, the OpenXR backend is selected. To use the OpenVR backend:
+- Start the SteamVR home application in your headset.
+- In Slicer, click on the wrench icon :wrench: in the toolbar, then select the OpenVR backend and enable rendering.
+
+_Supported headsets: Pro 2, Pro, Vive_
+
+_Supported XR modality: Virtual Reality_
 
 <a name="setup-windows-mixed-reality" ></a>
 
 ### How to set up my Windows Mixed Reality headset
 
-- Install Steam and SteamVR and set up your headset.
-- Set up [Windows Mixed Reality for SteamVR](https://docs.microsoft.com/en-us/windows/mixed-reality/enthusiast-guide/using-steamvr-with-windows-mixed-reality) (you should be able to see SteanVR home application running in your headset).
-- Install Slicer and SlicerVirtualReality extension.
-- To see content of content of the 3D view in your headset: click "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the toolbar in Slicer.
+- Set up [Windows Mixed Reality](https://learn.microsoft.com/en-us/windows/mixed-reality/enthusiast-guide/set-up-windows-mixed-reality).
+- Install Slicer and the SlicerVirtualReality extension.
+- To view content of the selected 3D view in your headset, click on the "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the Slicer toolbar.
+
+By default, the OpenXR backend is used. To use the OpenVR backend:
+ - Install [Steam][Steam-link] and [SteamVR][SteamVR-link].
+ - Set up [Windows Mixed Reality for SteamVR](https://docs.microsoft.com/en-us/windows/mixed-reality/enthusiast-guide/using-steamvr-with-windows-mixed-reality) (you should be able to see SteamVR home application running in your headset).
+ - In Slicer, click on the wrench icon :wrench: in the toolbar, then select the OpenVR backend and enable rendering.
+
+_See [here](https://en.wikipedia.org/wiki/Windows_Mixed_Reality#List_of_Windows_Mixed_Reality_headsets) for list of supported headsets._
+_Supported XR modality: Virtual Reality_
+
+<a name="setup-hololens-2" ></a>
+
+### How to set up my Hololens 2 headset
+
+- Set up [Windows Mixed Reality](https://learn.microsoft.com/en-us/windows/mixed-reality/enthusiast-guide/set-up-windows-mixed-reality)
+- Install Slicer and the SlicerVirtualReality extension.
+- On the Hololens, install and start the [Holographic Remoting Player](https://learn.microsoft.com/en-us/windows/mixed-reality/develop/native/holographic-remoting-player).
+- To view content of the selected 3D view in your headset, click on the wrench icon :wrench: in the toolbar, then select the OpenXR backend, enable remoting, enter the IP displayed in the remoting player running in the Hololens, and enable rendering.
+
+_Supported XR modality: Augmented Reality_
+
+<a name="setup-meta-quest" ></a>
+
+### How to set up my Meta Quest headset
+
+- Install [Oculus PC app][OculusSetup-link] and set up your headset.
+- Install Slicer and the SlicerVirtualReality extension.
+- To view content of the selected 3D view in your headset, click on the "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the Slicer toolbar.
+
+By default, the OpenXR backend is used. To use the OpenVR backend:
+- Install [Steam][Steam-link], [SteamVR][SteamVR-link] and start the SteamVR home application in your headset
+- In Slicer, click on the wrench icon :wrench: in the toolbar, then select the OpenVR backend and enable rendering.
+
+[OculusSetup-link]: https://www.meta.com/help/quest/articles/headsets-and-accessories/oculus-rift-s/install-app-for-link/
+
+_Supported headsets: Quest 3, Quest Pro, Quest 2, Quest_
+
+_Supported XR modality: Virtual Reality_
 
 <a name="setup-oculus-rift" ></a>
 
 ### How to set up my Oculus Rift headset
 
-- Install Steam and SteamVR and set up your headset to work with SteamVR.
-- Install Slicer and SlicerVirtualReality extension.
-- To see content of content of the 3D view in your headset:
+- Install [Oculus PC app][OculusSetup-link] and set up your headset.
+- Install Slicer and the SlicerVirtualReality extension.
+- To view content of the selected 3D view in your headset:
   - Start Oculus app (put on the headset for a moment and it will be started)
-  - Click the "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the toolbar in Slicer.
+  - Click on the "Show scene in virtual reality" button <img src="https://github.com/KitwareMedical/SlicerVirtualReality/raw/master/VirtualReality/Resources/Icons/VirtualRealityHeadset.png" width="24"> on the Slicer toolbar.
+
+By default, the OpenXR backend is used. To use the OpenVR backend:
+- Install [Steam][Steam-link], [SteamVR][SteamVR-link] and start the SteamVR home application in your headset.
+- In Slicer, click on the wrench icon :wrench: in the toolbar, then select the OpenVR backend and enable rendering.
+
+_Supported headsets: Rift S, Rift_
+
+_Supported XR modality: Virtual Reality_
+
+[Steam-link]: https://store.steampowered.com/about/
+[SteamVR-link]: https://store.steampowered.com/steamvr
 
 <a name="controllers" ></a>
 
@@ -105,11 +176,35 @@ Controls: press grip button when a controller is inside a selectable object
 > - By default all objects are selectable. An object can be made non-selectable (thus non-movable) in Data module / Subject hierarchy tab, right-clicking on the node and unchecking "Toggle Selectable".
 > - Moving of segmentation nodes is slow. If you want to move segmentations using controllers then export them to model nodes (in _Data_ module, right-click on the segmentation node and choose _Export visible segments to models_) and transform the model nodes.
 
+## How to use hand interaction
+
+See [Action poses for hand interactions](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#ext_hand_interaction-the-four-action-poses)
+
+### Fly
+
+_Not yet available._
+
+### Transform entire scene
+
+_Not yet available._
+
+### Transform objects
+
+Translate/rotate a selected object.
+
+Controls: do the "grip" or "pinch" pose when the hand is inside a selectable object
+
 ## Other features
 
 ### Accessing VR transforms (controller, headset, generic trackers) in Slicer
 
-Go to _Virtual Reality_ module and check the desired checkbox to update linear transform nodes with the various devices' positions. *Note:* The magnification factor in advanced settings affects these transforms.
+Go to _Virtual Reality_ module and check the desired checkbox to update linear transform nodes with the various devices' positions.
+
+> [!NOTE]
+>
+> * The magnification factor in advanced settings affects these transforms.
+>
+> * Generic trackers are only supported using the OpenVR backend.
 
 ## Frequently asked questions
 
@@ -144,7 +239,7 @@ There are several settings that help in increasing the performance of virtual re
 
 - If you are using a computer that has two graphics cards (for example, laptops often have an integrated Intel and a high-performance NVidia graphics card), make sure that Slicer is forced to use the high-performance card that the headset is connected to. Most laptops assign applications to the integrated card by default. When you need to select the application executable, choose `SlicerApp-real.exe` (and not the Slicer launcher application `Slicer.exe`).
 - Optimize scene for virtual reality button (magic wand icon on toolbar): this switches volume rendering to use GPU, turns off backface culling for all existing models (to see surfaces even when going inside an object), turns off slice intersection visibility for all existing models and segmentations (to make slice view updates faster)
-- Settings in virtual reality module panel related to performance (click on wrench icon in toolbar):
+- Settings in virtual reality module panel related to performance (click on wrench icon :wrench: in toolbar):
   - Update rate: Volume rendering quality is set to produce the highest possible quality while keeping the desired frame per second
   - Motion sensitivity: It is very important to keep rendering smooth when moving. This setting detects head movement and significantly lowers volume rendering quality while it is happening. At value of 0 motion is never detected, at high values a little motion triggers the quality change
 - Settings in Volume rendering module: open "Advanced" section / "Techniques" tab, try "Adaptive" setting with different "Interactive speed" values. Also try and "Normal" setting: it disables the automatic mechanism that tries to dynamically adjust rendering quality based on predicted rendering time (in some cases the prediction does not work well and results in sub-optimal image quality).
@@ -173,7 +268,7 @@ Information for developers is available in the [Developer Guide](DeveloperGuide.
 ## Contributors
 
 Contributors include:
-- Kitware: Jean-Christophe Fillion-Robin, Jean-Baptiste Vimort
+- Kitware: Jean-Christophe Fillion-Robin, Jean-Baptiste Vimort, Lucas Gandel, Sankhesh Jhaveri
 - PerkLab (Queen's University): Csaba Pinter, Andras Lasso
 - VASST Lab (Robarts Research Insitute): Adam Rankin
 


### PR DESCRIPTION
In the README:
- Revise the top-level and Setup sections to reflect OpenXR support.
- Update existing headset setup instructions to cover both OpenXR and OpenVR setups, with OpenXR being enabled by default. Added a note at the end of the section explaining how to enable OpenVR support.
- Add new sections for "Hololens 2" and "Meta Quest" headsets
- Add entries for "Supported headsets" and "Supported XR modality" to each headset section
- Add "How to use hand interaction" section
- Update the Contributors section to acknowledge @LucasGandel and @sankhesh.

In the DeveloperGuide:
- Remove obsolete build instructions.
- Update Python snippet.
- Add references to the documentation of associated VTK modules.
- Add the "Mapping of Controller Action to VTK event" section.
