### PR TITLE
COMP: Fix build error in Slicer-5.7 after vtkSingleton update in vtkAddon

### DIFF
--- a/VirtualReality/MRMLDM/vtkMRMLVirtualRealityViewDisplayableManagerFactory.cxx
+++ b/VirtualReality/MRMLDM/vtkMRMLVirtualRealityViewDisplayableManagerFactory.cxx
@@ -27,6 +27,11 @@
 //----------------------------------------------------------------------------
 // vtkMRMLVirtualRealityViewDisplayableManagerFactory methods
 
+#if ((Slicer_VERSION_MAJOR == 5 && Slicer_VERSION_MINOR >= 7) || (Slicer_VERSION_MAJOR > 5))
+  // When using current Slicer versions, the updated vtkSingleton class in vtkAddon does not need custom New and GetInstance methods.
+#else
+  // legacy implementation for Slicer<5.7
+
 //----------------------------------------------------------------------------
 // Up the reference count so it behaves like New
 vtkMRMLVirtualRealityViewDisplayableManagerFactory* vtkMRMLVirtualRealityViewDisplayableManagerFactory::New()
@@ -58,16 +63,15 @@ vtkMRMLVirtualRealityViewDisplayableManagerFactory* vtkMRMLVirtualRealityViewDis
   return Self::Instance;
 }
 
-//----------------------------------------------------------------------------
+#endif
+
 vtkMRMLVirtualRealityViewDisplayableManagerFactory::
     vtkMRMLVirtualRealityViewDisplayableManagerFactory():Superclass()
 {
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLVirtualRealityViewDisplayableManagerFactory::~vtkMRMLVirtualRealityViewDisplayableManagerFactory()
-{
-}
+vtkMRMLVirtualRealityViewDisplayableManagerFactory::~vtkMRMLVirtualRealityViewDisplayableManagerFactory() = default;
 
 //----------------------------------------------------------------------------
 void vtkMRMLVirtualRealityViewDisplayableManagerFactory::PrintSelf(ostream& os, vtkIndent indent)

--- a/VirtualReality/MRMLDM/vtkMRMLVirtualRealityViewDisplayableManagerFactory.h
+++ b/VirtualReality/MRMLDM/vtkMRMLVirtualRealityViewDisplayableManagerFactory.h
@@ -21,6 +21,11 @@
 #ifndef __vtkMRMLVirtualRealityViewDisplayableManagerFactory_h
 #define __vtkMRMLVirtualRealityViewDisplayableManagerFactory_h
 
+// For:
+//  - Slicer_VERSION_MAJOR
+//  - Slicer_VERSION_MINOR
+#include <vtkSlicerVersionConfigureMinimal.h>
+
 // VR MRMLDM includes
 #include "vtkSlicerVirtualRealityModuleMRMLDisplayableManagerExport.h"
 
@@ -63,8 +68,14 @@ protected:
 
 private:
 
+#if ((Slicer_VERSION_MAJOR == 5 && Slicer_VERSION_MINOR >= 7) || (Slicer_VERSION_MAJOR > 5))
+  vtkMRMLVirtualRealityViewDisplayableManagerFactory(const vtkMRMLVirtualRealityViewDisplayableManagerFactory&) = delete;
+  void operator=(const vtkMRMLVirtualRealityViewDisplayableManagerFactory&) = delete;
+#else
+  // legacy implementation for Slicer<5.7
   vtkMRMLVirtualRealityViewDisplayableManagerFactory(const vtkMRMLVirtualRealityViewDisplayableManagerFactory&);
   void operator=(const vtkMRMLVirtualRealityViewDisplayableManagerFactory&);
+#endif
 
 };
 

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -335,7 +335,7 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
       << "vtkMRMLMarkupsDisplayableManager"
       << "vtkMRMLSegmentationsDisplayableManager3D"
       << "vtkMRMLTransformsDisplayableManager3D"
-#if (Slicer_VERSION_MAJOR >= 5 && Slicer_VERSION_MINOR >= 7)
+#if ((Slicer_VERSION_MAJOR == 5 && Slicer_VERSION_MINOR >= 7) || (Slicer_VERSION_MAJOR > 5))
       << "vtkMRMLLinearTransformsDisplayableManager"
 #else
       << "vtkMRMLLinearTransformsDisplayableManager3D"


### PR DESCRIPTION
This commit added a new, simplified vtkSingleton to vtkAddon: https://github.com/Slicer/vtkAddon/commit/3f317421da77b9f6fd48aaf40608545db4fec3e0 This required a simplification of the vtkMRMLVirtualRealityViewDisplayableManagerFactory singleton class.