### PR TITLE
ENH: Disable Markups occlusion in VR views

### DIFF
--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -53,6 +53,8 @@ vtkMRMLVirtualRealityViewNode::vtkMRMLVirtualRealityViewNode()
   this->BackgroundColor2[0] = this->defaultBackgroundColor2()[0];
   this->BackgroundColor2[1] = this->defaultBackgroundColor2()[1];
   this->BackgroundColor2[2] = this->defaultBackgroundColor2()[2];
+  // Computation of markup visibility is very expensive operation, as it requires transfer
+  // of the Z-buffer from the GPU to the CPU, therefore we disable it by default for VR views.
   this->MarkupsOcclusionEnabled = false;
 }
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -53,6 +53,7 @@ vtkMRMLVirtualRealityViewNode::vtkMRMLVirtualRealityViewNode()
   this->BackgroundColor2[0] = this->defaultBackgroundColor2()[0];
   this->BackgroundColor2[1] = this->defaultBackgroundColor2()[1];
   this->BackgroundColor2[2] = this->defaultBackgroundColor2()[2];
+  this->MarkupsOcclusionEnabled = false;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Assume all markup points visible to avoid occlusion check overhead.

Requires this PR in Slicer to add the flag: https://github.com/Slicer/Slicer/pull/8979.