### PR TITLE
ENH: Update OpenXR to 1.1.60 and enable passthrough

### DIFF
--- a/SuperBuild/External_OpenXR-SDK.cmake
+++ b/SuperBuild/External_OpenXR-SDK.cmake
@@ -26,7 +26,7 @@ if(NOT OpenXR_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${SUPERBUILD_TOPLEVEL_PROJECT}_${proj}_GIT_TAG
-    "release-1.0.33"
+    "release-1.1.60"
     QUIET
     )
 

--- a/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
+++ b/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.cxx
@@ -24,8 +24,10 @@
 // MRML includes
 #include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelDisplayNode.h>
+#include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSegmentationDisplayNode.h>
+#include <vtkMRMLVectorVolumeNode.h>
 
 // Slicer includes
 #include <vtkSlicerVolumeRenderingLogic.h>
@@ -805,4 +807,40 @@ std::string vtkSlicerVirtualRealityLogic::ComputeActionManifestPath(
   }
 
   return actionManifestPath;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLVectorVolumeNode* vtkSlicerVirtualRealityLogic::GetOrCreateVRSceneColorVolumeNode()
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+  {
+    return nullptr;
+  }
+  vtkMRMLVectorVolumeNode* node = vtkMRMLVectorVolumeNode::SafeDownCast(
+    scene->GetFirstNodeByName("VR Scene (Left Eye)"));
+  if (!node)
+  {
+    node = vtkMRMLVectorVolumeNode::SafeDownCast(
+      scene->AddNewNodeByClass("vtkMRMLVectorVolumeNode", "VR Scene (Left Eye)"));
+  }
+  return node;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLScalarVolumeNode* vtkSlicerVirtualRealityLogic::GetOrCreatePassthroughDepthVolumeNode()
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+  {
+    return nullptr;
+  }
+  vtkMRMLScalarVolumeNode* node = vtkMRMLScalarVolumeNode::SafeDownCast(
+    scene->GetFirstNodeByName("Passthrough Depth"));
+  if (!node)
+  {
+    node = vtkMRMLScalarVolumeNode::SafeDownCast(
+      scene->AddNewNodeByClass("vtkMRMLScalarVolumeNode", "Passthrough Depth"));
+  }
+  return node;
 }

--- a/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.h
+++ b/VirtualReality/Logic/vtkSlicerVirtualRealityLogic.h
@@ -33,6 +33,8 @@
 // Slicer includes
 #include <vtkSlicerModuleLogic.h>
 class vtkSlicerVolumeRenderingLogic;
+class vtkMRMLScalarVolumeNode;
+class vtkMRMLVectorVolumeNode;
 
 // VTK/Rendering/VR includes
 class vtkVRRenderWindowInteractor;
@@ -106,6 +108,14 @@ public:
 
   /// Set volume rendering logic
   void SetVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* volumeRenderingLogic);
+
+  /// Get the VR scene color (left-eye rendered frame) volume node, creating it if it does not exist.
+  /// Returns nullptr if no MRML scene is set.
+  vtkMRMLVectorVolumeNode* GetOrCreateVRSceneColorVolumeNode();
+
+  /// Get the passthrough depth volume node, creating it if it does not exist.
+  /// Returns nullptr if no MRML scene is set.
+  vtkMRMLScalarVolumeNode* GetOrCreatePassthroughDepthVolumeNode();
 
   /// Determines whether rendering should occur as quick view motion.
   ///

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.cxx
@@ -89,6 +89,11 @@ void vtkMRMLVirtualRealityViewNode::WriteXML(ostream& of, int nIndent)
   // OpenXRRemoting
   vtkMRMLWriteXMLBooleanMacro(remoting, Remoting);
   vtkMRMLWriteXMLStdStringMacro(playerIPAddress, PlayerIPAddress);
+  vtkMRMLWriteXMLBooleanMacro(passthrough, Passthrough);
+  vtkMRMLWriteXMLFloatMacro(occludedOpacity, OccludedOpacity);
+  vtkMRMLWriteXMLBooleanMacro(envDepthDebugVisualization, EnvDepthDebugVisualization);
+  vtkMRMLWriteXMLBooleanMacro(vrSceneColorVolumeEnabled, VRSceneColorVolumeEnabled);
+  vtkMRMLWriteXMLBooleanMacro(passthroughDepthVolumeEnabled, PassthroughDepthVolumeEnabled);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -114,6 +119,11 @@ void vtkMRMLVirtualRealityViewNode::ReadXMLAttributes(const char** atts)
   // OpenXRRemoting
   vtkMRMLReadXMLBooleanMacro(remoting, Remoting);
   vtkMRMLReadXMLStdStringMacro(playerIPAddress, PlayerIPAddress);
+  vtkMRMLReadXMLBooleanMacro(passthrough, Passthrough);
+  vtkMRMLReadXMLFloatMacro(occludedOpacity, OccludedOpacity);
+  vtkMRMLReadXMLBooleanMacro(envDepthDebugVisualization, EnvDepthDebugVisualization);
+  vtkMRMLReadXMLBooleanMacro(vrSceneColorVolumeEnabled, VRSceneColorVolumeEnabled);
+  vtkMRMLReadXMLBooleanMacro(passthroughDepthVolumeEnabled, PassthroughDepthVolumeEnabled);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -143,6 +153,11 @@ void vtkMRMLVirtualRealityViewNode::Copy(vtkMRMLNode* anode)
   // OpenXRRemoting
   vtkMRMLCopyBooleanMacro(Remoting);
   vtkMRMLCopyStringMacro(PlayerIPAddress);
+  vtkMRMLCopyBooleanMacro(Passthrough);
+  vtkMRMLCopyFloatMacro(OccludedOpacity);
+  vtkMRMLCopyBooleanMacro(EnvDepthDebugVisualization);
+  vtkMRMLCopyBooleanMacro(VRSceneColorVolumeEnabled);
+  vtkMRMLCopyBooleanMacro(PassthroughDepthVolumeEnabled);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -168,6 +183,11 @@ void vtkMRMLVirtualRealityViewNode::PrintSelf(ostream& os, vtkIndent indent)
   // OpenXRRemoting
   vtkMRMLPrintBooleanMacro(Remoting);
   vtkMRMLPrintStdStringMacro(PlayerIPAddress);
+  vtkMRMLPrintBooleanMacro(Passthrough);
+  vtkMRMLPrintFloatMacro(OccludedOpacity);
+  vtkMRMLPrintBooleanMacro(EnvDepthDebugVisualization);
+  vtkMRMLPrintBooleanMacro(VRSceneColorVolumeEnabled);
+  vtkMRMLPrintBooleanMacro(PassthroughDepthVolumeEnabled);
   vtkMRMLPrintEndMacro();
 }
 

--- a/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
+++ b/VirtualReality/MRML/vtkMRMLVirtualRealityViewNode.h
@@ -255,6 +255,73 @@ public:
   vtkGetMacro(PlayerIPAddress, std::string);
   ///@}
 
+  ///@{
+  /// Enable camera passthrough (mixed reality / AR mode) for OpenXR.
+  ///
+  /// When enabled, the real-world view seen through the headset cameras is
+  /// blended with the rendered 3D scene using
+  /// XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND.  The scene background is rendered
+  /// fully transparent so the camera feed shows through.
+  ///
+  /// This option only has an effect when the XR backend is OpenXR and the
+  /// runtime supports XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND (e.g. Meta Quest 3
+  /// via Quest Link / Air Link).
+  ///
+  /// Changing this setting requires reconnecting to the headset.
+  vtkGetMacro(Passthrough, bool);
+  vtkSetMacro(Passthrough, bool);
+  vtkBooleanMacro(Passthrough, bool);
+  ///@}
+
+  ///@{
+  /// Opacity applied to virtual geometry that is occluded by real-world
+  /// surfaces when XR_META_environment_depth occlusion is active.
+  ///
+  ///  0.0 (default) – fully occluded (hard depth pre-pass).
+  ///  0.0 < x < 1.0 – partial occlusion (post-pass alpha blend).
+  ///  1.0            – no depth composition (bypass entirely).
+  ///
+  /// Has no effect when env-depth is unavailable or inactive.
+  vtkGetMacro(OccludedOpacity, double);
+  vtkSetClampMacro(OccludedOpacity, double, 0.0, 1.0);
+  ///@}
+
+  ///@{
+  /// Show a false-colour overlay of the real-world depth texture for debugging.
+  /// Red = near (0 m), blue = far (~5 m).
+  /// Has no effect when XR_META_environment_depth is unavailable or inactive.
+  vtkGetMacro(EnvDepthDebugVisualization, bool);
+  vtkSetMacro(EnvDepthDebugVisualization, bool);
+  vtkBooleanMacro(EnvDepthDebugVisualization, bool);
+  ///@}
+
+  ///@{
+  /// If enabled, the rendered left-eye VR scene is captured each render tick
+  /// and written to a vtkMRMLVectorVolumeNode named "VR Scene (Left Eye)"
+  /// (RGB, unsigned char).
+  ///
+  /// The captured image is the rendered VR scene for the left eye as submitted
+  /// to the display. This is not the raw headset camera feed; it is the
+  /// composited output of the VR renderer (geometry, overlays, etc.).
+  /// When XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND (passthrough) is active,
+  /// transparent areas will include the real-world camera feed composited by
+  /// the runtime, but the primary content is the rendered scene.
+  vtkGetMacro(VRSceneColorVolumeEnabled, bool);
+  vtkSetMacro(VRSceneColorVolumeEnabled, bool);
+  vtkBooleanMacro(VRSceneColorVolumeEnabled, bool);
+  ///@}
+
+  ///@{
+  /// If enabled, the real-world environment depth is captured each render tick
+  /// (via XR_META_environment_depth) and written to a vtkMRMLScalarVolumeNode
+  /// named "Passthrough Depth".  Scalar values are in millimetres (float).
+  ///
+  /// Has no effect if XR_META_environment_depth is unavailable or inactive.
+  vtkGetMacro(PassthroughDepthVolumeEnabled, bool);
+  vtkSetMacro(PassthroughDepthVolumeEnabled, bool);
+  vtkBooleanMacro(PassthroughDepthVolumeEnabled, bool);
+  ///@}
+
   /// Return true if an error has occurred.
   /// "Connected" member requests connection but this method can tell if the
   /// hardware connection has been actually successfully established.
@@ -289,6 +356,17 @@ protected:
   // OpenXRRemoting
   bool Remoting{false};
   std::string PlayerIPAddress;
+
+  // Passthrough (OpenXR alpha blend mode)
+  bool Passthrough{false};
+
+  // Environment-depth occlusion (XR_META_environment_depth)
+  double OccludedOpacity{1.0};
+  bool EnvDepthDebugVisualization{false};
+
+  // VR scene / passthrough volume capture
+  bool VRSceneColorVolumeEnabled{false};
+  bool PassthroughDepthVolumeEnabled{false};
 
   vtkMRMLVirtualRealityViewNode();
   ~vtkMRMLVirtualRealityViewNode() override;

--- a/VirtualReality/MRMLDM/vtkVirtualRealityViewInteractorObserver.cxx
+++ b/VirtualReality/MRMLDM/vtkVirtualRealityViewInteractorObserver.cxx
@@ -254,7 +254,7 @@ bool vtkVirtualRealityViewInteractorObserver::DelegateInteractionEventDataToDisp
   else if (vrViewInteractor && vrViewInteractor->GetCurrentGesture() == vtkCommand::NoEvent)
     {
     // Report an error message only if the interactor is not processing a complex gesture.
-    vtkErrorMacro("DelegateInteractionEventDataToDisplayableManagers: Unrecognized device");
+    vtkErrorMacro("DelegateInteractionEventDataToDisplayableManagers: Unrecognized device " << int(ed->GetDevice()));
     }
   ed->SetInteractionContextName(interactionContextName);
 

--- a/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
+++ b/VirtualReality/Resources/UI/qSlicerVirtualRealityModuleWidget.ui
@@ -65,13 +65,122 @@
        </layout>
       </item>
       <item row="2" column="0">
+       <widget class="QLabel" name="EnablePassthroughLabel">
+        <property name="text">
+         <string>Enable Passthrough:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="PassthroughEnabledCheckBox">
+        <property name="toolTip">
+         <string>Enable camera passthrough (mixed reality mode) for OpenXR. Requires a headset that supports XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND, such as Meta Quest 3 via Quest Link. Changing this setting requires reconnecting to the headset.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="OccludedOpacityLabel">
+        <property name="text">
+         <string>Occluded opacity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ctkSliderWidget" name="OccludedOpacitySlider">
+        <property name="toolTip">
+         <string>Opacity of virtual geometry that is occluded by real-world surfaces (XR_META_environment_depth). 0 = fully hidden, 1 = fully visible (no occlusion).</string>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="singleStep">
+         <double>0.050000000000000</double>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="EnvDepthDebugLabel">
+        <property name="text">
+         <string>Depth debug overlay:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="EnvDepthDebugCheckBox">
+        <property name="toolTip">
+         <string>Show a false-colour overlay of the real-world depth texture (red = near, blue = far). Requires XR_META_environment_depth support.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="VRSceneColorVolumeLabel">
+        <property name="text">
+         <string>VR scene color volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="VRSceneColorVolumeCheckBox">
+        <property name="toolTip">
+         <string>Capture the rendered left-eye VR scene each tick into a vtkMRMLVectorVolumeNode named "VR Scene (Left Eye)" (RGB). This captures the composited output of the VR renderer, not the raw headset camera feed.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="PassthroughDepthVolumeLabel">
+        <property name="text">
+         <string>Passthrough depth volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QCheckBox" name="PassthroughDepthVolumeCheckBox">
+        <property name="toolTip">
+         <string>Capture the real-world environment depth (XR_META_environment_depth) each tick into a vtkMRMLScalarVolumeNode named "Passthrough Depth". Values are in millimetres. Requires XR_META_environment_depth support.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
        <widget class="QLabel" name="ConnectToHardwareLabel">
         <property name="text">
          <string>Connect to hardware:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="7" column="1">
        <layout class="QHBoxLayout" name="ConnectionLayout">
         <item>
          <widget class="ctkCheckBox" name="ConnectCheckBox"/>
@@ -128,14 +237,14 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="EnableRenderingLabel">
         <property name="text">
          <string>Enable rendering:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="8" column="1">
        <widget class="ctkCheckBox" name="RenderingEnabledCheckBox"/>
       </item>
      </layout>

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -78,7 +78,9 @@
 // MRML includes
 #include <vtkMRMLCameraNode.h>
 #include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScene.h>
+#include <vtkMRMLVectorVolumeNode.h>
 
 #if defined(SlicerVirtualReality_HAS_OPENVR_SUPPORT)
 // VTK Rendering/OpenVR includes
@@ -94,6 +96,7 @@
 #if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
 // VTK Rendering/OpenXR includes
 #include <vtkOpenXRCamera.h>
+#include <vtkOpenXRManager.h>
 #include <vtkOpenXRModel.h>
 #include <vtkOpenXRRenderWindow.h>
 #include <vtkOpenXRRenderer.h>
@@ -101,7 +104,6 @@
 
 #if defined(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
 // VTK Rendering/OpenXRRemoting includes
-#include <vtkOpenXRManager.h>
 #include <vtkOpenXRRemotingRenderWindow.h>
 #endif
 
@@ -111,9 +113,13 @@
 #include <vtkVRRenderWindow.h>
 #include <vtkVRRenderWindowInteractor.h>
 
+// VTK OpenGL loader (provides raw OpenGL 4.x function pointers)
+#include <vtk_glad.h>
+
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkCullerCollection.h>
+#include <vtkImageData.h>
 #include <vtkLight.h>
 #include <vtkLightCollection.h>
 #include <vtkNew.h>
@@ -133,17 +139,17 @@ namespace
   {
     switch (result)
     {
-      case vr::TrackingResult_Calibrating_InProgress:
-        return "CalibratingInProgress";
-      case vr::TrackingResult_Calibrating_OutOfRange:
-        return "CalibratingOutOfRange";
-      case vr::TrackingResult_Running_OK:
-        return "RunningOk";
-      case vr::TrackingResult_Running_OutOfRange:
-        return "RunningOutOfRange";
-      case vr::TrackingResult_Uninitialized:
-      default:
-        return "Uninitialized";
+    case vr::TrackingResult_Calibrating_InProgress:
+      return "CalibratingInProgress";
+    case vr::TrackingResult_Calibrating_OutOfRange:
+      return "CalibratingOutOfRange";
+    case vr::TrackingResult_Running_OK:
+      return "RunningOk";
+    case vr::TrackingResult_Running_OutOfRange:
+      return "RunningOutOfRange";
+    case vr::TrackingResult_Uninitialized:
+    default:
+      return "Uninitialized";
     }
   }
 #endif
@@ -249,38 +255,59 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
   else
 #endif
 #if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
-  if (xrBackend == vtkMRMLVirtualRealityViewNode::OpenXR)
-  {
-    vtkNew<vtkVirtualRealityViewOpenXRInteractorStyle> interactorStyle;
-    interactorStyle->SetInteractorStyleDelegate(this->InteractorStyleDelegate);
+    if (xrBackend == vtkMRMLVirtualRealityViewNode::OpenXR)
+    {
+      vtkNew<vtkVirtualRealityViewOpenXRInteractorStyle> interactorStyle;
+      interactorStyle->SetInteractorStyleDelegate(this->InteractorStyleDelegate);
 
 #if defined(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
-    if (this->MRMLVirtualRealityViewNode->GetRemoting())
-    {
-      vtkSmartPointer<vtkOpenXRRemotingRenderWindow> xrRemotingRenderWindow = vtkSmartPointer<vtkOpenXRRemotingRenderWindow>::New();
-      xrRemotingRenderWindow->SetRemotingIPAddress(this->MRMLVirtualRealityViewNode->GetPlayerIPAddress().c_str());
-      // Address "wglDXRegisterObjectNV failed in RegisterSharedTexture()" reported when using "OpenXRRemoting"
-      xrRemotingRenderWindow->GetHelperWindow()->SetMultiSamples(0);
-      this->RenderWindow = xrRemotingRenderWindow;
+      if (this->MRMLVirtualRealityViewNode->GetRemoting())
+      {
+        vtkSmartPointer<vtkOpenXRRemotingRenderWindow> xrRemotingRenderWindow = vtkSmartPointer<vtkOpenXRRemotingRenderWindow>::New();
+        xrRemotingRenderWindow->SetRemotingIPAddress(this->MRMLVirtualRealityViewNode->GetPlayerIPAddress().c_str());
+        // Address "wglDXRegisterObjectNV failed in RegisterSharedTexture()" reported when using "OpenXRRemoting"
+        xrRemotingRenderWindow->GetHelperWindow()->SetMultiSamples(0);
+        this->RenderWindow = xrRemotingRenderWindow;
+      }
+      else
+#endif
+      {
+        this->RenderWindow = vtkSmartPointer<vtkOpenXRRenderWindow>::New();
+      }
+      this->Renderer = vtkSmartPointer<vtkOpenXRRenderer>::New();
+      this->InteractorStyle = interactorStyle;
+      this->Interactor = vtkSmartPointer<vtkVirtualRealityViewOpenXRInteractor>::New();
+      this->Camera = vtkSmartPointer<vtkOpenXRCamera>::New();
+
+      // Configure passthrough and occlusion before Initialize() is called.
+      // SelectExtensions() (called during Initialize) checks these values to decide
+      // which XR extensions to load; they cannot be changed without a reconnect.
+      {
+        vtkOpenXRRenderWindow* xrRenderWindow = vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow);
+        if (xrRenderWindow)
+        {
+          if (this->MRMLVirtualRealityViewNode->GetPassthrough())
+          {
+            xrRenderWindow->SetUsePassthrough(true);
+          }
+          // OccludedOpacity < 1.0 requires XR_META_environment_depth to be loaded at Init time.
+          xrRenderWindow->SetOccludedOpacity(
+            0.0);
+          // Also request env depth when depth volume capture is enabled, even if
+          // depth occlusion is not active (OccludedOpacity == 1.0).
+          xrRenderWindow->SetCaptureEnvironmentDepth(
+            this->MRMLVirtualRealityViewNode->GetPassthroughDepthVolumeEnabled());
+        }
+      }
     }
     else
 #endif
     {
-      this->RenderWindow = vtkSmartPointer<vtkOpenXRRenderWindow>::New();
+      this->destroyRenderWindow();
+      qWarning() << "No XR backend initialized";
+      this->MRMLVirtualRealityViewNode->SetError("Connection failed: No XR backend initialized");
+      return;
     }
-    this->Renderer = vtkSmartPointer<vtkOpenXRRenderer>::New();
-    this->InteractorStyle = interactorStyle;
-    this->Interactor = vtkSmartPointer<vtkVirtualRealityViewOpenXRInteractor>::New();
-    this->Camera = vtkSmartPointer<vtkOpenXRCamera>::New();
-  }
-  else
-#endif
-  {
-    this->destroyRenderWindow();
-    qWarning() << "No XR backend initialized";
-    this->MRMLVirtualRealityViewNode->SetError("Connection failed: No XR backend initialized");
-    return;
-  }
 
   // InteractorStyle
   this->InteractorStyle->SetCurrentRenderer(this->Renderer);
@@ -309,10 +336,15 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
 
   // Observe VR render window event
   qvtkReconnect(this->RenderWindow, vtkVRRenderWindow::PhysicalToWorldMatrixModified,
-                q, SLOT(onPhysicalToWorldMatrixModified()));
+    q, SLOT(onPhysicalToWorldMatrixModified()));
+
+  // Observe renderer EndEvent to capture passthrough volume data while the
+  // rendering FBO is still valid (before swapchain release).
+  qvtkReconnect(this->Renderer, vtkCommand::EndEvent,
+    this, SLOT(onRendererEndEvent()));
 
   // Observe button press event
-  qvtkReconnect(this->Interactor, vtkCommand::Button3DEvent, q, SLOT(onButton3DEvent(vtkObject*,void*,unsigned long,void*)));
+  qvtkReconnect(this->Interactor, vtkCommand::Button3DEvent, q, SLOT(onButton3DEvent(vtkObject*, void*, unsigned long, void*)));
 
   //
   // DisplayableManager registration
@@ -323,26 +355,26 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
 
   QStringList displayableManagers;
   displayableManagers
-      // Slicer
-      //<< "vtkMRMLCameraDisplayableManager" // Not supported in VR, vtkVRCamera has no MRML node counterpart
-      //<< "vtkMRMLViewDisplayableManager" // Not supported in VR, require a vtkMRMLCameraNode
-      << "vtkMRMLModelDisplayableManager"
-      << "vtkMRMLThreeDReformatDisplayableManager"
-      << "vtkMRMLCrosshairDisplayableManager3D"
-      //<< "vtkMRMLOrientationMarkerDisplayableManager" // Not supported in VR
-      //<< "vtkMRMLRulerDisplayableManager" // Not supported in VR
-      //<< "vtkMRMLAnnotationDisplayableManager" // Not supported in VR
-      << "vtkMRMLMarkupsDisplayableManager"
-      << "vtkMRMLSegmentationsDisplayableManager3D"
-      << "vtkMRMLTransformsDisplayableManager3D"
+    // Slicer
+    //<< "vtkMRMLCameraDisplayableManager" // Not supported in VR, vtkVRCamera has no MRML node counterpart
+    //<< "vtkMRMLViewDisplayableManager" // Not supported in VR, require a vtkMRMLCameraNode
+    << "vtkMRMLModelDisplayableManager"
+    << "vtkMRMLThreeDReformatDisplayableManager"
+    << "vtkMRMLCrosshairDisplayableManager3D"
+    //<< "vtkMRMLOrientationMarkerDisplayableManager" // Not supported in VR
+    //<< "vtkMRMLRulerDisplayableManager" // Not supported in VR
+    //<< "vtkMRMLAnnotationDisplayableManager" // Not supported in VR
+    << "vtkMRMLMarkupsDisplayableManager"
+    << "vtkMRMLSegmentationsDisplayableManager3D"
+    << "vtkMRMLTransformsDisplayableManager3D"
 #if ((Slicer_VERSION_MAJOR == 5 && Slicer_VERSION_MINOR >= 7) || (Slicer_VERSION_MAJOR > 5))
-      << "vtkMRMLLinearTransformsDisplayableManager"
+    << "vtkMRMLLinearTransformsDisplayableManager"
 #else
-      << "vtkMRMLLinearTransformsDisplayableManager3D"
+    << "vtkMRMLLinearTransformsDisplayableManager3D"
 #endif
-      << "vtkMRMLVolumeRenderingDisplayableManager"
-      ;
-  foreach (const QString& displayableManager, displayableManagers)
+    << "vtkMRMLVolumeRenderingDisplayableManager"
+    ;
+  foreach(const QString & displayableManager, displayableManagers)
   {
     if (!factory->IsDisplayableManagerRegistered(displayableManager.toLatin1()))
     {
@@ -351,14 +383,14 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
   }
 
   this->DisplayableManagerGroup = vtkSmartPointer<vtkMRMLDisplayableManagerGroup>::Take(
-                                    factory->InstantiateDisplayableManagers(q->renderer()));
+    factory->InstantiateDisplayableManagers(q->renderer()));
   this->DisplayableManagerGroup->SetMRMLDisplayableNode(this->MRMLVirtualRealityViewNode);
   this->InteractorStyleDelegate->SetDisplayableManagers(this->DisplayableManagerGroup);
   this->InteractorObserver->SetDisplayableManagers(this->DisplayableManagerGroup);
 
   // Default inputs mapping
   vtkSlicerVirtualRealityLogic::SetTriggerButtonFunction(
-        this->Interactor, vtkSlicerVirtualRealityLogic::GetButtonFunctionIdForGrabObjectsAndWorld());
+    this->Interactor, vtkSlicerVirtualRealityLogic::GetButtonFunctionIdForGrabObjectsAndWorld());
 
   ///CONFIGURATION OF THE OPENVR ENVIRONEMENT
 
@@ -413,6 +445,44 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
     return;
   }
 
+  // If passthrough was requested, report the outcome.
+  // XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND is active immediately after Initialize();
+  // XR_FB_passthrough objects are created during Initialize() but xrPassthroughStartFB()
+  // is deferred to BeginSession() (first render tick), so IsFBPassthroughActive() is
+  // still false here — use IsFBPassthroughSupported() to report that it is pending.
+  // If neither mechanism is available, warn the user.
+#if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+  if (this->MRMLVirtualRealityViewNode->GetPassthrough())
+  {
+    vtkOpenXRRenderWindow* xrRenderWindow = vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow);
+    if (xrRenderWindow)
+    {
+      if (xrRenderWindow->IsPassthroughActive())
+      {
+        // XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND is active right now.
+        qDebug() << "SlicerVirtualReality: Passthrough active (ALPHA_BLEND blend mode).";
+      }
+      else if (vtkOpenXRManager::GetInstance().IsFBPassthroughSupported())
+      {
+        // XR_FB_passthrough extension found and objects created; passthrough will
+        // activate on the first render tick when BeginSession() is called.
+        qDebug() << "SlicerVirtualReality: XR_FB_passthrough objects created; "
+          "passthrough will activate when the XR session starts.";
+      }
+      else
+      {
+        qWarning() << "SlicerVirtualReality: Passthrough requested but no passthrough "
+          "mechanism is available (neither XR_FB_passthrough nor "
+          "XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND is supported by the runtime). "
+          "VR rendering continues with normal background. "
+          "For Meta Quest 3 via Quest Link: enable developer mode on the headset "
+          "and ensure 'Allow apps to access passthrough' is enabled in the "
+          "Meta XR PC app (Settings > General).";
+      }
+    }
+  }
+#endif
+
   // Keep track of last valid parameters in the settings
   QSettings().setValue("VirtualReality/DefaultXRBackend", xrBackendAsStr);
 #if defined(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
@@ -426,7 +496,7 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
   qDebug() << "ActionManifestPath:" << q->actionManifestPath();
   qDebug() << "Number of registered displayable manager:" << this->DisplayableManagerGroup->GetDisplayableManagerCount();
   qDebug() << "Registered displayable managers:";
-  for (int idx=0; idx < this->DisplayableManagerGroup->GetDisplayableManagerCount(); idx++)
+  for (int idx = 0; idx < this->DisplayableManagerGroup->GetDisplayableManagerCount(); idx++)
   {
     qDebug() << " " << this->DisplayableManagerGroup->GetNthDisplayableManager(idx)->GetClassName();
   }
@@ -437,6 +507,24 @@ void qMRMLVirtualRealityViewPrivate::createRenderWindow(vtkMRMLVirtualRealityVie
 void qMRMLVirtualRealityViewPrivate::destroyRenderWindow()
 {
   this->VirtualRealityLoopTimer.stop();
+
+  // Release OpenGL resources that we own while the render window's
+  // GL context is still valid.
+  if (this->RenderWindow != nullptr)
+  {
+    this->RenderWindow->MakeCurrent();
+    if (this->DepthBlitFBO != 0)
+    {
+      glDeleteFramebuffers(1, &this->DepthBlitFBO);
+      this->DepthBlitFBO = 0;
+    }
+    if (this->DepthBlitTexture != 0)
+    {
+      glDeleteTextures(1, &this->DepthBlitTexture);
+      this->DepthBlitTexture = 0;
+    }
+  }
+
   // Must break the connection between interactor and render window,
   // otherwise they would circularly refer to each other and would not
   // be deleted.
@@ -469,15 +557,15 @@ vtkMRMLVirtualRealityViewNode::XRBackendType qMRMLVirtualRealityViewPrivate::cur
 #if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
   if (vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow) != nullptr
 #if defined(SlicerVirtualReality_HAS_OPENXRREMOTING_SUPPORT)
-      || vtkOpenXRRemotingRenderWindow::SafeDownCast(this->RenderWindow) != nullptr
+    || vtkOpenXRRemotingRenderWindow::SafeDownCast(this->RenderWindow) != nullptr
 #endif
-      )
+    )
   {
     return vtkMRMLVirtualRealityViewNode::OpenXR;
   }
 #endif
   qCritical() << Q_FUNC_INFO << " failed: RenderWindow is not a supported type: "
-              << this->RenderWindow->GetClassName();
+    << this->RenderWindow->GetClassName();
   return vtkMRMLVirtualRealityViewNode::UndefinedXRBackend;
 }
 
@@ -502,13 +590,26 @@ std::string qMRMLVirtualRealityViewPrivate::currentXRBackendRemotingIPAddress() 
 }
 
 // --------------------------------------------------------------------------
+bool qMRMLVirtualRealityViewPrivate::currentXRBackendPassthroughEnabled() const
+{
+#if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+  vtkOpenXRRenderWindow* xrRenderWindow = vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow);
+  if (xrRenderWindow != nullptr)
+  {
+    return xrRenderWindow->GetUsePassthrough();
+  }
+#endif
+  return false;
+}
+
+// --------------------------------------------------------------------------
 void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRML()
 {
   if (this->IsUpdatingWidgetFromMRML)
-    {
+  {
     // Updating widget from MRML is already in progress
     return;
-    }
+  }
   this->IsUpdatingWidgetFromMRML = true;
 
   this->updateWidgetFromMRMLNoModify();
@@ -531,8 +632,9 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
 
   // Reset initialization attempts and clear errors if the XR backend has changed
   if (this->currentXRBackend() != this->MRMLVirtualRealityViewNode->GetXRBackend()
-      || this->currentXRBackendRemotingEnabled() != this->MRMLVirtualRealityViewNode->GetRemoting()
-      || this->currentXRBackendRemotingIPAddress() != this->MRMLVirtualRealityViewNode->GetPlayerIPAddress())
+    || this->currentXRBackendRemotingEnabled() != this->MRMLVirtualRealityViewNode->GetRemoting()
+    || this->currentXRBackendRemotingIPAddress() != this->MRMLVirtualRealityViewNode->GetPlayerIPAddress()
+    || this->currentXRBackendPassthroughEnabled() != this->MRMLVirtualRealityViewNode->GetPassthrough())
   {
     this->InitializationAttempts = 0;
     this->MRMLVirtualRealityViewNode->ClearError();
@@ -541,10 +643,11 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
   // Attempt to initialize XR backend if the current backend differs or is undefined, and
   // the view is visible (i.e., connected to the hardware)
   if ((this->currentXRBackend() != this->MRMLVirtualRealityViewNode->GetXRBackend()
-       || this->currentXRBackendRemotingEnabled() != this->MRMLVirtualRealityViewNode->GetRemoting()
-       || this->currentXRBackendRemotingIPAddress() != this->MRMLVirtualRealityViewNode->GetPlayerIPAddress()
-       || this->currentXRBackend() == vtkMRMLVirtualRealityViewNode::UndefinedXRBackend)
-      && this->MRMLVirtualRealityViewNode->GetVisibility())
+    || this->currentXRBackendRemotingEnabled() != this->MRMLVirtualRealityViewNode->GetRemoting()
+    || this->currentXRBackendRemotingIPAddress() != this->MRMLVirtualRealityViewNode->GetPlayerIPAddress()
+    || this->currentXRBackendPassthroughEnabled() != this->MRMLVirtualRealityViewNode->GetPassthrough()
+    || this->currentXRBackend() == vtkMRMLVirtualRealityViewNode::UndefinedXRBackend)
+    && this->MRMLVirtualRealityViewNode->GetVisibility())
   {
     // Bail if there are no more attempts left
     constexpr int maximumNumberOfAttempts = 1;
@@ -560,8 +663,8 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
 
     // Log the initialization attempt
     qDebug().noquote().nospace()
-        << "Initializing \"" << xrBackendAsStr << "\" XR backend "
-        << QString("(%1/%2)").arg(this->InitializationAttempts).arg(maximumNumberOfAttempts);
+      << "Initializing \"" << xrBackendAsStr << "\" XR backend "
+      << QString("(%1/%2)").arg(this->InitializationAttempts).arg(maximumNumberOfAttempts);
 
     // Destroy and recreate the render window
     this->destroyRenderWindow();
@@ -570,7 +673,7 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
 
   // Skip further updates if the XR backend is undefined or if the view node has an error
   if (this->currentXRBackend() == vtkMRMLVirtualRealityViewNode::UndefinedXRBackend
-      || this->MRMLVirtualRealityViewNode->HasError())
+    || this->MRMLVirtualRealityViewNode->HasError())
   {
     return;
   }
@@ -581,8 +684,29 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
   }
 
   // Renderer properties
-  if (this->MRMLVirtualRealityViewNode->GetRemoting())
+  // Use a transparent background only when the runtime has actually granted
+  // XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND (passthrough/AR mode).  If passthrough
+  // was requested but the runtime fell back to OPAQUE, use the normal gradient
+  // background so the user doesn't see an unwanted black screen.
+  // For XR_FB_passthrough, IsPassthroughActive() returns false until BeginSession()
+  // runs on the first render tick, so also check IsFBPassthroughSupported() — if
+  // handles were successfully created, passthrough will be active imminently and
+  // we should set the transparent background now.
+  bool passthroughActive = false;
+#if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+  if (this->MRMLVirtualRealityViewNode->GetPassthrough())
   {
+    vtkOpenXRRenderWindow* xrRenderWindow = vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow);
+    passthroughActive = xrRenderWindow && xrRenderWindow->GetVRInitialized() &&
+      (xrRenderWindow->IsPassthroughActive() ||
+        vtkOpenXRManager::GetInstance().IsFBPassthroughSupported());
+  }
+#endif
+
+  if (this->MRMLVirtualRealityViewNode->GetRemoting() || passthroughActive)
+  {
+    // Use a transparent background so the real-world passthrough (or remoting
+    // AR background) shows through wherever no 3D content is rendered.
     this->Renderer->SetGradientBackground(0);
     this->Renderer->SetBackground(0.0, 0.0, 0.0);
     this->Renderer->SetBackgroundAlpha(0.0);
@@ -625,7 +749,7 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
     this->InteractorStyleDelegate->SetMagnification(magnification);
 
     // Dolly physical speed
-    double dollyPhysicalSpeedMps = this ->MRMLVirtualRealityViewNode->GetMotionSpeed();
+    double dollyPhysicalSpeedMps = this->MRMLVirtualRealityViewNode->GetMotionSpeed();
 
     // 1.6666 m/s is walking speed (= 6 km/h), which is the default. We multiply it with the factor
     this->InteractorStyle->SetDollyPhysicalSpeed(dollyPhysicalSpeedMps);
@@ -661,6 +785,21 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
       }
     }
 #endif
+
+#if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+    {
+      vtkOpenXRRenderWindow* xrRenderWindow = vtkOpenXRRenderWindow::SafeDownCast(this->RenderWindow);
+      if (xrRenderWindow)
+      {
+        xrRenderWindow->SetOccludedOpacity(
+          static_cast<float>(this->MRMLVirtualRealityViewNode->GetOccludedOpacity()));
+        xrRenderWindow->SetShowEnvDepthDebugVisualization(
+          this->MRMLVirtualRealityViewNode->GetEnvDepthDebugVisualization());
+        // Note: CaptureEnvironmentDepth must be set before session creation (in createRenderWindow).
+        // Updating it here has no effect on an already-running session.
+      }
+    }
+#endif
   }
 
   if (this->MRMLVirtualRealityViewNode->GetActive())
@@ -670,6 +809,17 @@ void qMRMLVirtualRealityViewPrivate::updateWidgetFromMRMLNoModify()
   else
   {
     this->VirtualRealityLoopTimer.stop();
+  }
+
+  // Ensure volume nodes exist as soon as the capture flags are toggled on,
+  // regardless of whether data is currently flowing.
+  if (this->MRMLVirtualRealityViewNode->GetPassthroughDepthVolumeEnabled())
+  {
+    this->VirtualRealityLogic->GetOrCreatePassthroughDepthVolumeNode();
+  }
+  if (this->MRMLVirtualRealityViewNode->GetVRSceneColorVolumeEnabled())
+  {
+    this->VirtualRealityLogic->GetOrCreateVRSceneColorVolumeNode();
   }
 }
 
@@ -723,24 +873,28 @@ void qMRMLVirtualRealityViewPrivate::doOpenVirtualReality()
 #endif
   if (this->RenderWindow->GetVRInitialized() && hmdConnected)
   {
+    // Reset staging flags so onRendererEndEvent() captures fresh data this frame.
+    this->ColorStagingHasData = false;
+    this->DepthStagingHasData = false;
+
     this->Interactor->DoOneEvent(this->RenderWindow, this->Renderer);
 
     this->LastViewUpdateTime->StopTimer();
     if (this->LastViewUpdateTime->GetElapsedTime() > 0.0)
     {
       bool quickViewMotion =
-          vtkSlicerVirtualRealityLogic::ShouldConsiderQuickViewMotion(
-            this->MRMLVirtualRealityViewNode->GetMotionSensitivity(),
-            this->RenderWindow->GetPhysicalScale(),
-            this->LastViewUpdateTime->GetElapsedTime(),
-            // position and orientation since last view update
-            this->LastViewPosition,
-            this->LastViewDirection,
-            this->LastViewUp,
-            // current view position and orientation
-            this->Camera->GetPosition(),
-            this->Camera->GetViewPlaneNormal(),
-            this->Camera->GetViewUp());
+        vtkSlicerVirtualRealityLogic::ShouldConsiderQuickViewMotion(
+          this->MRMLVirtualRealityViewNode->GetMotionSensitivity(),
+          this->RenderWindow->GetPhysicalScale(),
+          this->LastViewUpdateTime->GetElapsedTime(),
+          // position and orientation since last view update
+          this->LastViewPosition,
+          this->LastViewDirection,
+          this->LastViewUp,
+          // current view position and orientation
+          this->Camera->GetPosition(),
+          this->Camera->GetViewPlaneNormal(),
+          this->Camera->GetViewUp());
 
       double updateRate = quickViewMotion ? this->desiredUpdateRate() : this->stillUpdateRate();
       this->RenderWindow->SetDesiredUpdateRate(updateRate);
@@ -764,6 +918,12 @@ void qMRMLVirtualRealityViewPrivate::doOpenVirtualReality()
       if (this->MRMLVirtualRealityViewNode->GetTrackerTransformUpdate())
       {
         updateTransformNodesWithTrackerPoses();
+      }
+
+      if (this->MRMLVirtualRealityViewNode->GetVRSceneColorVolumeEnabled() ||
+        this->MRMLVirtualRealityViewNode->GetPassthroughDepthVolumeEnabled())
+      {
+        this->updatePassthroughVolumeNodes();
       }
 
       this->LastViewUpdateTime->StartTimer();
@@ -821,6 +981,182 @@ void qMRMLVirtualRealityViewPrivate::updateTransformNodesWithTrackerPoses()
 }
 
 //----------------------------------------------------------------------------
+void qMRMLVirtualRealityViewPrivate::onRendererEndEvent()
+{
+  if (!this->MRMLVirtualRealityViewNode)
+  {
+    return;
+  }
+
+  // --- Color (left-eye rendered frame) ---
+  if (this->MRMLVirtualRealityViewNode->GetVRSceneColorVolumeEnabled()
+    && !this->ColorStagingHasData)
+  {
+    GLint viewport[4] = { 0, 0, 0, 0 };
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    int w = viewport[2];
+    int h = viewport[3];
+    if (w > 0 && h > 0)
+    {
+      this->ColorStaging.resize(static_cast<size_t>(w) * h * 3);
+      glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, this->ColorStaging.data());
+      this->ColorStagingWidth = w;
+      this->ColorStagingHeight = h;
+      this->ColorStagingHasData = true;
+    }
+  }
+
+  // --- Depth (XR_META_environment_depth, left eye, layer 0) ---
+#if defined(SlicerVirtualReality_HAS_OPENXR_SUPPORT)
+  if (this->MRMLVirtualRealityViewNode->GetPassthroughDepthVolumeEnabled()
+    && !this->DepthStagingHasData)
+  {
+#ifdef XR_META_environment_depth
+    vtkOpenXRManager& mgr = vtkOpenXRManager::GetInstance();
+    if (mgr.IsEnvironmentDepthActive())
+    {
+      uint32_t texId = mgr.GetEnvDepthTextureId();
+      if (texId != 0)
+      {
+        // DSA query — no bind needed, works regardless of texture target.
+        GLint w = 0, h = 0;
+        glGetTextureLevelParameteriv(texId, 0, GL_TEXTURE_WIDTH, &w);
+        glGetTextureLevelParameteriv(texId, 0, GL_TEXTURE_HEIGHT, &h);
+
+        if (w > 0 && h > 0)
+        {
+          // Build or reuse the staging FBO.
+          // No staging texture needed — we read directly from the depth
+          // attachment via GL_DEPTH_COMPONENT.
+          if (this->DepthBlitFBO == 0)
+          {
+            glGenFramebuffers(1, &this->DepthBlitFBO);
+          }
+
+          // Save current FBO state before touching anything
+          GLint prevFBO = 0;
+          glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFBO);
+
+          glBindFramebuffer(GL_FRAMEBUFFER, this->DepthBlitFBO);
+
+          // Attach layer 0 (left eye) of the XR depth texture as the
+          // depth attachment — this is the only attach mode that works
+          // for a depth-format swapchain texture on this runtime.
+          glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+            texId, 0 /*mip*/, 0 /*layer=left eye*/);
+
+          GLenum fbStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+          if (fbStatus != GL_FRAMEBUFFER_COMPLETE)
+          {
+            qWarning() << "EnvDepth: FBO incomplete: 0x" << Qt::hex << fbStatus;
+          }
+          else
+          {
+            // Flush any pre-existing GL errors before our readback
+            while (glGetError() != GL_NO_ERROR) {}
+
+            this->DepthStaging.resize(static_cast<size_t>(w) * h);
+            glReadPixels(0, 0, w, h, GL_DEPTH_COMPONENT, GL_FLOAT,
+              this->DepthStaging.data());
+
+            GLenum err = glGetError();
+            if (err != GL_NO_ERROR)
+            {
+              qWarning() << "EnvDepth glReadPixels failed: 0x" << Qt::hex << err;
+            }
+            else
+            {
+              // Convert metres → millimetres.
+              for (float& v : this->DepthStaging)
+              {
+                v *= 1000.0f;
+              }
+              this->DepthStagingWidth = w;
+              this->DepthStagingHeight = h;
+              this->DepthStagingHasData = true;
+            }
+          }
+
+          // Detach and restore XR texture
+          glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, 0, 0, 0);
+          glBindFramebuffer(GL_FRAMEBUFFER, prevFBO);
+        }
+      }
+    }
+#endif // XR_META_environment_depth
+  }
+#endif // SlicerVirtualReality_HAS_OPENXR_SUPPORT
+}
+
+//----------------------------------------------------------------------------
+// Copy from CPU staging buffers (filled during rendering) into MRML volume
+// nodes.  No OpenGL calls are made here — the swapchain images have already
+// been released at this point.
+void qMRMLVirtualRealityViewPrivate::updatePassthroughVolumeNodes()
+{
+  if (!this->MRMLVirtualRealityViewNode)
+  {
+    return;
+  }
+
+  // --- Depth volume ---
+  if (this->MRMLVirtualRealityViewNode->GetPassthroughDepthVolumeEnabled()
+    && this->DepthStagingHasData)
+  {
+    vtkMRMLScalarVolumeNode* volNode =
+      this->VirtualRealityLogic->GetOrCreatePassthroughDepthVolumeNode();
+    if (volNode)
+    {
+      vtkImageData* img = volNode->GetImageData();
+      if (!img ||
+        img->GetDimensions()[0] != this->DepthStagingWidth ||
+        img->GetDimensions()[1] != this->DepthStagingHeight)
+      {
+        vtkNew<vtkImageData> newImg;
+        newImg->SetDimensions(this->DepthStagingWidth, this->DepthStagingHeight, 1);
+        newImg->AllocateScalars(VTK_FLOAT, 1);
+        volNode->SetAndObserveImageData(newImg);
+        img = volNode->GetImageData();
+      }
+      memcpy(img->GetScalarPointer(),
+        this->DepthStaging.data(),
+        this->DepthStaging.size() * sizeof(float));
+      img->Modified();
+      volNode->Modified();
+    }
+    this->DepthStagingHasData = false;
+  }
+
+  // --- Color volume ---
+  if (this->MRMLVirtualRealityViewNode->GetVRSceneColorVolumeEnabled()
+    && this->ColorStagingHasData)
+  {
+    vtkMRMLVectorVolumeNode* volNode =
+      this->VirtualRealityLogic->GetOrCreateVRSceneColorVolumeNode();
+    if (volNode)
+    {
+      vtkImageData* img = volNode->GetImageData();
+      if (!img ||
+        img->GetDimensions()[0] != this->ColorStagingWidth ||
+        img->GetDimensions()[1] != this->ColorStagingHeight)
+      {
+        vtkNew<vtkImageData> newImg;
+        newImg->SetDimensions(this->ColorStagingWidth, this->ColorStagingHeight, 1);
+        newImg->AllocateScalars(VTK_UNSIGNED_CHAR, 3);
+        volNode->SetAndObserveImageData(newImg);
+        img = volNode->GetImageData();
+      }
+      memcpy(img->GetScalarPointer(),
+        this->ColorStaging.data(),
+        this->ColorStaging.size());
+      img->Modified();
+      volNode->Modified();
+    }
+    this->ColorStagingHasData = false;
+  }
+}
+
+//----------------------------------------------------------------------------
 void qMRMLVirtualRealityViewPrivate
 ::updateTransformNodeAttributesFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index)
 {
@@ -833,23 +1169,23 @@ void qMRMLVirtualRealityViewPrivate
 
   std::string attributePrefix;
 
-  switch(device)
+  switch (device)
   {
-    case vtkEventDataDevice::HeadMountedDisplay:
-      attributePrefix = "HMD";
-      break;
-    case vtkEventDataDevice::RightController:
-      attributePrefix = "Controller";
-      break;
-    case vtkEventDataDevice::LeftController:
-      attributePrefix = "Controller";
-      break;
-    case vtkEventDataDevice::GenericTracker:
-      attributePrefix = "Tracker";
-      break;
-    default:
-      attributePrefix = "Unknown";
-      break;
+  case vtkEventDataDevice::HeadMountedDisplay:
+    attributePrefix = "HMD";
+    break;
+  case vtkEventDataDevice::RightController:
+    attributePrefix = "Controller";
+    break;
+  case vtkEventDataDevice::LeftController:
+    attributePrefix = "Controller";
+    break;
+  case vtkEventDataDevice::GenericTracker:
+    attributePrefix = "Tracker";
+    break;
+  default:
+    attributePrefix = "Unknown";
+    break;
   }
 
   vr::TrackedDevicePose_t* tdPose;
@@ -857,24 +1193,24 @@ void qMRMLVirtualRealityViewPrivate
   if (tdPose == nullptr)
   {
     auto handle = this->RenderWindow->GetDeviceHandleForDevice(device, index);
-    switch(device)
+    switch (device)
     {
-      case vtkEventDataDevice::HeadMountedDisplay:
-        qCritical() << Q_FUNC_INFO << ": Unable to retrieve HMD pose";
-        break;
-      case vtkEventDataDevice::RightController:
-        qCritical() << Q_FUNC_INFO << ": Unable to retrieve RightController pose";
-        break;
-      case vtkEventDataDevice::LeftController:
-        qCritical() << Q_FUNC_INFO << ": Unable to retrieve LeftController pose";
-        break;
-      case vtkEventDataDevice::GenericTracker:
-        qCritical() << Q_FUNC_INFO << ": Unable to retrieve pose associated with VR tracker"
-                    << "(index: " << index << ", handle: " << handle << ")";
-        break;
-      default:
-        qCritical() << Q_FUNC_INFO << ": Unable to retrieve pose associated with unknown device";
-        break;
+    case vtkEventDataDevice::HeadMountedDisplay:
+      qCritical() << Q_FUNC_INFO << ": Unable to retrieve HMD pose";
+      break;
+    case vtkEventDataDevice::RightController:
+      qCritical() << Q_FUNC_INFO << ": Unable to retrieve RightController pose";
+      break;
+    case vtkEventDataDevice::LeftController:
+      qCritical() << Q_FUNC_INFO << ": Unable to retrieve LeftController pose";
+      break;
+    case vtkEventDataDevice::GenericTracker:
+      qCritical() << Q_FUNC_INFO << ": Unable to retrieve pose associated with VR tracker"
+        << "(index: " << index << ", handle: " << handle << ")";
+      break;
+    default:
+      qCritical() << Q_FUNC_INFO << ": Unable to retrieve pose associated with unknown device";
+      break;
     }
     return;
   }
@@ -903,9 +1239,9 @@ void qMRMLVirtualRealityViewPrivate
 {
   auto deviceHandle = this->RenderWindow->GetDeviceHandleForDevice(device, index);
   if (deviceHandle == UINT32_MAX /* InvalidDeviceIndex or vr::k_unTrackedDeviceIndexInvalid */)
-    {
+  {
     return;
-    }
+  }
   vtkMatrix4x4* pose = this->RenderWindow->GetDeviceToPhysicalMatrixForDeviceHandle(deviceHandle);
   if (!pose)
   {
@@ -933,7 +1269,7 @@ void qMRMLVirtualRealityViewPrivate
 
 // --------------------------------------------------------------------------
 qMRMLVirtualRealityView::qMRMLVirtualRealityView(QWidget* _parent) : Superclass(_parent)
-  , d_ptr(new qMRMLVirtualRealityViewPrivate(*this))
+, d_ptr(new qMRMLVirtualRealityViewPrivate(*this))
 {
   Q_D(qMRMLVirtualRealityView);
   d->init();
@@ -1100,11 +1436,11 @@ void qMRMLVirtualRealityView::onButton3DEvent(vtkObject* caller, void* call_data
   Q_UNUSED(vtk_event);
   Q_UNUSED(client_data);
 
-  vtkEventDataDevice3D * ed = reinterpret_cast<vtkEventDataDevice3D*>(call_data);
+  vtkEventDataDevice3D* ed = reinterpret_cast<vtkEventDataDevice3D*>(call_data);
 
-  if(ed->GetInput() == vtkEventDataDeviceInput::Trigger)
+  if (ed->GetInput() == vtkEventDataDeviceInput::Trigger)
   {
-    if(ed->GetDevice() == vtkEventDataDevice::LeftController)
+    if (ed->GetDevice() == vtkEventDataDevice::LeftController)
     {
       if (ed->GetAction() == vtkEventDataAction::Press)
       {
@@ -1158,7 +1494,7 @@ void qMRMLVirtualRealityView::onButton3DEvent(vtkObject* caller, void* call_data
     {
       if (ed->GetAction() == vtkEventDataAction::Press)
       {
-        emit leftControllerTrackpadPressed(ed->GetTrackPadPosition()[0],ed->GetTrackPadPosition()[1]);
+        emit leftControllerTrackpadPressed(ed->GetTrackPadPosition()[0], ed->GetTrackPadPosition()[1]);
       }
       else if (ed->GetAction() == vtkEventDataAction::Release)
       {

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView_p.h
@@ -61,6 +61,12 @@ class vtkLightCollection;
 class vtkObject;
 class vtkTimerLog;
 
+// VTK OpenGL loader (provides raw OpenGL 4.x function pointers)
+#include <vtk_glad.h>
+
+// STD includes
+#include <vector>
+
 // CTK includes
 #include <ctkVTKObject.h>
 
@@ -70,11 +76,11 @@ class vtkTimerLog;
 #include <QTimer>
 
 //-----------------------------------------------------------------------------
-class qMRMLVirtualRealityViewPrivate: public QObject
+class qMRMLVirtualRealityViewPrivate : public QObject
 {
   Q_OBJECT
-  QVTK_OBJECT
-  Q_DECLARE_PUBLIC(qMRMLVirtualRealityView);
+    QVTK_OBJECT
+    Q_DECLARE_PUBLIC(qMRMLVirtualRealityView);
 protected:
   qMRMLVirtualRealityView* const q_ptr;
 public:
@@ -92,10 +98,15 @@ public:
   vtkMRMLVirtualRealityViewNode::XRBackendType currentXRBackend() const;
   bool currentXRBackendRemotingEnabled() const;
   std::string currentXRBackendRemotingIPAddress() const;
+  bool currentXRBackendPassthroughEnabled() const;
 
 public slots:
   void updateWidgetFromMRML();
   void doOpenVirtualReality();
+  /// Called at the end of each eye's renderer pass.
+  /// Captures color and/or depth data into CPU staging buffers while
+  /// the rendering FBO is still valid (before swapchain release).
+  void onRendererEndEvent();
 
 protected:
   void updateWidgetFromMRMLNoModify();
@@ -103,8 +114,13 @@ protected:
   void updateTransformNodeWithHMDPose();
   void updateTransformNodesWithTrackerPoses();
 
-  void updateTransformNodeFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index=0);
-  void updateTransformNodeAttributesFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index=0);
+  void updateTransformNodeFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index = 0);
+  void updateTransformNodeAttributesFromDevice(vtkMRMLTransformNode* node, vtkEventDataDevice device, uint32_t index = 0);
+
+  /// Capture VR scene color and/or passthrough depth data into MRML volume nodes.
+  /// Called each render tick when VRSceneColorVolumeEnabled or
+  /// PassthroughDepthVolumeEnabled is set on the view node.
+  void updatePassthroughVolumeNodes();
 
   void createRenderWindow(vtkMRMLVirtualRealityViewNode::XRBackendType xrBackend);
   void destroyRenderWindow();
@@ -133,8 +149,26 @@ protected:
 
   QString ActionManifestPath;
 
-  bool IsUpdatingWidgetFromMRML{false};
-  int InitializationAttempts{0};
+  bool IsUpdatingWidgetFromMRML{ false };
+  int InitializationAttempts{ 0 };
+
+  // Staging buffers for passthrough volume data captured during rendering.
+  // Filled in onRendererEndEvent() (FBO valid), consumed in updatePassthroughVolumeNodes().
+  bool ColorStagingHasData{ false };
+  std::vector<unsigned char> ColorStaging; // RGB, VTK_UNSIGNED_CHAR
+  int ColorStagingWidth{ 0 };
+  int ColorStagingHeight{ 0 };
+
+  bool DepthStagingHasData{ false };
+  std::vector<float> DepthStaging; // depth in mm, VTK_FLOAT
+  int DepthStagingWidth{ 0 };
+  int DepthStagingHeight{ 0 };
+
+  // In the private class header:
+  GLuint DepthBlitTexture{ 0 };
+  GLuint DepthBlitFBO{ 0 };
+  GLint  DepthBlitWidth{ 0 };
+  GLint  DepthBlitHeight{ 0 };
 
   QTimer VirtualRealityLoopTimer;
 };

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.cxx
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.cxx
@@ -95,6 +95,11 @@ void qSlicerVirtualRealityModuleWidget::setup()
   connect(d->XRBackendComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(setVirtualRealityXRBackend(int)));
   connect(d->RemotingEnabledCheckBox, SIGNAL(toggled(bool)), this, SLOT(setRemotingEnabled(bool)));
   connect(d->PlayerIPAddressLineEdit, SIGNAL(editingFinished()), this, SLOT(onPlayerIPAddressLineEditEditingFinished()));
+  connect(d->PassthroughEnabledCheckBox, SIGNAL(toggled(bool)), this, SLOT(setPassthroughEnabled(bool)));
+  connect(d->VRSceneColorVolumeCheckBox, SIGNAL(toggled(bool)), this, SLOT(setVRSceneColorVolumeEnabled(bool)));
+  connect(d->PassthroughDepthVolumeCheckBox, SIGNAL(toggled(bool)), this, SLOT(setPassthroughDepthVolumeEnabled(bool)));
+  connect(d->OccludedOpacitySlider, SIGNAL(valueChanged(double)), this, SLOT(onOccludedOpacityChanged(double)));
+  connect(d->EnvDepthDebugCheckBox, SIGNAL(toggled(bool)), this, SLOT(setEnvDepthDebugVisualization(bool)));
 
   connect(d->ConnectCheckBox, SIGNAL(toggled(bool)), this, SLOT(setVirtualRealityConnected(bool)));
   connect(d->RenderingEnabledCheckBox, SIGNAL(toggled(bool)), this, SLOT(setVirtualRealityActive(bool)));
@@ -122,6 +127,17 @@ void qSlicerVirtualRealityModuleWidget::setup()
 
   // If virtual reality logic is modified it indicates that the view node may have changed
   qvtkConnect(logic(), vtkCommand::ModifiedEvent, this, SLOT(updateWidgetFromMRML()));
+
+  // TODO: Currently the depth opacity is not functional with the latest version of the Meta headset.
+  // Hide the widget until it can be fixed.
+  d->OccludedOpacityLabel->setHidden(true);
+  d->OccludedOpacitySlider->setHidden(true);
+  d->PassthroughDepthVolumeLabel->setHidden(true);
+  d->PassthroughDepthVolumeCheckBox->setHidden(true);
+  d->EnvDepthDebugLabel->setHidden(true);
+  d->EnvDepthDebugCheckBox->setHidden(true);
+  d->VRSceneColorVolumeLabel->setHidden(true);
+  d->VRSceneColorVolumeCheckBox->setHidden(true);
 }
 
 //--------------------------------------------------------------------------
@@ -241,6 +257,43 @@ void qSlicerVirtualRealityModuleWidget::updateWidgetFromMRML()
         && vrViewNode->GetRemoting());
   d->PlayerIPAddressLineEdit->setReadOnly(vrLogic->GetVirtualRealityConnected());
   d->PlayerIPAddressLineEdit->blockSignals(wasBlocked);
+
+  // Passthrough
+  wasBlocked = d->PassthroughEnabledCheckBox->blockSignals(true);
+  d->PassthroughEnabledCheckBox->setChecked(vrViewNode != nullptr ? vrViewNode->GetPassthrough() : false);
+  d->PassthroughEnabledCheckBox->setEnabled(
+        (vrViewNode != nullptr)
+        && vrViewNode->GetXRBackend() == vtkMRMLVirtualRealityViewNode::OpenXR
+        && !vrLogic->GetVirtualRealityConnected());
+  d->PassthroughEnabledCheckBox->blockSignals(wasBlocked);
+
+  // Environment-depth occlusion
+  wasBlocked = d->OccludedOpacitySlider->blockSignals(true);
+  d->OccludedOpacitySlider->setValue(vrViewNode != nullptr ? vrViewNode->GetOccludedOpacity() : 0.0);
+  d->OccludedOpacitySlider->setEnabled(vrViewNode != nullptr
+        && vrViewNode->GetXRBackend() == vtkMRMLVirtualRealityViewNode::OpenXR);
+  d->OccludedOpacitySlider->blockSignals(wasBlocked);
+
+  wasBlocked = d->EnvDepthDebugCheckBox->blockSignals(true);
+  d->EnvDepthDebugCheckBox->setChecked(vrViewNode != nullptr ? vrViewNode->GetEnvDepthDebugVisualization() : false);
+  d->EnvDepthDebugCheckBox->setEnabled(vrViewNode != nullptr
+        && vrViewNode->GetXRBackend() == vtkMRMLVirtualRealityViewNode::OpenXR);
+  d->EnvDepthDebugCheckBox->blockSignals(wasBlocked);
+
+  // VR scene color volume capture
+  wasBlocked = d->VRSceneColorVolumeCheckBox->blockSignals(true);
+  d->VRSceneColorVolumeCheckBox->setChecked(
+    vrViewNode != nullptr ? vrViewNode->GetVRSceneColorVolumeEnabled() : false);
+  d->VRSceneColorVolumeCheckBox->setEnabled(vrViewNode != nullptr && vrLogic->GetVirtualRealityActive());
+  d->VRSceneColorVolumeCheckBox->blockSignals(wasBlocked);
+
+  wasBlocked = d->PassthroughDepthVolumeCheckBox->blockSignals(true);
+  d->PassthroughDepthVolumeCheckBox->setChecked(
+    vrViewNode != nullptr ? vrViewNode->GetPassthroughDepthVolumeEnabled() : false);
+  d->PassthroughDepthVolumeCheckBox->setEnabled(vrViewNode != nullptr
+        && vrViewNode->GetXRBackend() == vtkMRMLVirtualRealityViewNode::OpenXR
+        && vrLogic->GetVirtualRealityActive());
+  d->PassthroughDepthVolumeCheckBox->blockSignals(wasBlocked);
 }
 
 
@@ -475,6 +528,61 @@ void qSlicerVirtualRealityModuleWidget::setRemotingEnabled(bool enabled)
   if (vrViewNode)
   {
     vrViewNode->SetRemoting(enabled);
+  }
+}
+
+//----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::setPassthroughEnabled(bool enabled)
+{
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetPassthrough(enabled);
+  }
+}
+
+//----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::setVRSceneColorVolumeEnabled(bool enabled)
+{
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetVRSceneColorVolumeEnabled(enabled);
+  }
+}
+
+//----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::setPassthroughDepthVolumeEnabled(bool enabled)
+{
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetPassthroughDepthVolumeEnabled(enabled);
+  }
+}
+
+//----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::onOccludedOpacityChanged(double value)
+{
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetOccludedOpacity(value);
+  }
+}
+
+//----------------------------------------------------------------------------
+void qSlicerVirtualRealityModuleWidget::setEnvDepthDebugVisualization(bool enabled)
+{
+  vtkSlicerVirtualRealityLogic* vrLogic = vtkSlicerVirtualRealityLogic::SafeDownCast(this->logic());
+  vtkMRMLVirtualRealityViewNode* vrViewNode = vrLogic->GetVirtualRealityViewNode();
+  if (vrViewNode)
+  {
+    vrViewNode->SetEnvDepthDebugVisualization(enabled);
   }
 }
 

--- a/VirtualReality/qSlicerVirtualRealityModuleWidget.h
+++ b/VirtualReality/qSlicerVirtualRealityModuleWidget.h
@@ -57,6 +57,13 @@ public slots:
   // OpenXRRemoting
   void setRemotingEnabled(bool);
   void onPlayerIPAddressLineEditEditingFinished();
+  // Passthrough
+  void setPassthroughEnabled(bool);
+  void setVRSceneColorVolumeEnabled(bool);
+  void setPassthroughDepthVolumeEnabled(bool);
+  // Environment-depth occlusion
+  void onOccludedOpacityChanged(double);
+  void setEnvDepthDebugVisualization(bool);
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
Updates the bundled OpenXR SDK to the current version (1.1.60) and adds AR passthrough (XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND) to vtkMRMLVirtualRealityViewNode / qMRMLVirtualRealityView.

Also adds groundwork for environment-depth occlusion (XR_META_environment_depth), debug visualization, and VR scene/depth volume capture. These controls are hidden in the module UI for now, since depth occlusion is not functional with the current Meta runtime.