### PR TITLE
BUG: Fix VR interactor reference cycle leak

### DIFF
--- a/VirtualReality/MRMLDM/vtkVirtualRealityComplexGestureRecognizer.cxx
+++ b/VirtualReality/MRMLDM/vtkVirtualRealityComplexGestureRecognizer.cxx
@@ -35,7 +35,12 @@ vtkStandardNewMacro(vtkVirtualRealityComplexGestureRecognizer);
 //----------------------------------------------------------------------------
 void vtkVirtualRealityComplexGestureRecognizer::SetInteractor(vtkVRRenderWindowInteractor* interactor)
 {
-  vtkSetSmartPointerBodyMacro(Interactor, vtkVRRenderWindowInteractor, interactor);
+  if (this->Interactor == interactor)
+  {
+    return;
+  }
+  this->Interactor = interactor;
+  this->Modified();
 }
 
 //----------------------------------------------------------------------------

--- a/VirtualReality/MRMLDM/vtkVirtualRealityComplexGestureRecognizer.h
+++ b/VirtualReality/MRMLDM/vtkVirtualRealityComplexGestureRecognizer.h
@@ -27,7 +27,7 @@ class vtkVRRenderWindowInteractor;
 
 // VTK includes
 #include <vtkObject.h>
-#include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
 class vtkEventData;
 class vtkEventDataDevice3D;
 
@@ -42,6 +42,9 @@ public:
 
   ///@{
   /// Interactor to recognize the complex gestures from.
+  /// The interactor owns this recognizer, so only a weak reference is kept:
+  /// a strong reference would create a cycle that prevents the interactor
+  /// (and the renderer, camera, props, pickers it retains) from being deleted.
   void SetInteractor(vtkVRRenderWindowInteractor* interactor);
   vtkVRRenderWindowInteractor* GetInteractor() const;
   ///}@
@@ -53,7 +56,7 @@ public:
   ///@}
 
 protected:
-  vtkSmartPointer<vtkVRRenderWindowInteractor> Interactor;
+  vtkWeakPointer<vtkVRRenderWindowInteractor> Interactor;
 
 private:
   vtkVirtualRealityComplexGestureRecognizer() = default;

--- a/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityView.cxx
@@ -1297,6 +1297,11 @@ vtkVirtualRealityViewInteractorObserver* qMRMLVirtualRealityView::interactorObse
 void qMRMLVirtualRealityView::addDisplayableManager(const QString& displayableManagerName)
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->DisplayableManagerGroup)
+  {
+    qWarning() << Q_FUNC_INFO << " failed: VR view is not connected";
+    return;
+  }
   vtkSmartPointer<vtkMRMLAbstractDisplayableManager> displayableManager;
   displayableManager.TakeReference(
     vtkMRMLDisplayableManagerGroup::InstantiateDisplayableManager(
@@ -1352,6 +1357,10 @@ void qMRMLVirtualRealityView::getDisplayableManagers(vtkCollection* displayableM
 void qMRMLVirtualRealityView::setGrabObjectsEnabled(bool enable)
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->InteractorStyleDelegate)
+  {
+    return;
+  }
   d->InteractorStyleDelegate->SetGrabEnabled(enable);
 }
 
@@ -1359,6 +1368,10 @@ void qMRMLVirtualRealityView::setGrabObjectsEnabled(bool enable)
 bool qMRMLVirtualRealityView::isGrabObjectsEnabled()
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->InteractorStyleDelegate)
+  {
+    return false;
+  }
   return d->InteractorStyleDelegate->GetGrabEnabled();
 }
 
@@ -1372,6 +1385,11 @@ void qMRMLVirtualRealityView::setDolly3DEnabled(bool enable)
   // - `vtk_openvr_binding_*.json` files define the "button to action" mapping
   // - `vtkOpenVRInteractorStyle()` contructor defines the "action to eventId" mapping
 
+  if (!d->InteractorStyle)
+  {
+    // VR is not connected (interactor style is only created while connected)
+    return;
+  }
   if (enable)
   {
     d->InteractorStyle->MapInputToAction(vtkCommand::ViewerMovement3DEvent, VTKIS_DOLLY);
@@ -1386,7 +1404,10 @@ void qMRMLVirtualRealityView::setDolly3DEnabled(bool enable)
 bool qMRMLVirtualRealityView::isDolly3DEnabled()
 {
   Q_D(qMRMLVirtualRealityView);
-
+  if (!d->InteractorStyle)
+  {
+    return false;
+  }
   return d->InteractorStyle->GetMappedAction(vtkCommand::ViewerMovement3DEvent) == VTKIS_DOLLY;
 }
 
@@ -1394,6 +1415,10 @@ bool qMRMLVirtualRealityView::isDolly3DEnabled()
 void qMRMLVirtualRealityView::setGestureButtonToTrigger()
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->Interactor)
+  {
+    return;
+  }
   vtkSlicerVirtualRealityLogic::SetGestureButtonToTrigger(d->Interactor);
 }
 
@@ -1401,6 +1426,10 @@ void qMRMLVirtualRealityView::setGestureButtonToTrigger()
 void qMRMLVirtualRealityView::setGestureButtonToGrip()
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->Interactor)
+  {
+    return;
+  }
   vtkSlicerVirtualRealityLogic::SetGestureButtonToGrip(d->Interactor);
 }
 
@@ -1408,6 +1437,10 @@ void qMRMLVirtualRealityView::setGestureButtonToGrip()
 void qMRMLVirtualRealityView::setGestureButtonToTriggerAndGrip()
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->Interactor)
+  {
+    return;
+  }
   vtkSlicerVirtualRealityLogic::SetGestureButtonToTriggerAndGrip(d->Interactor);
 }
 
@@ -1415,6 +1448,10 @@ void qMRMLVirtualRealityView::setGestureButtonToTriggerAndGrip()
 void qMRMLVirtualRealityView::setGestureButtonToNone()
 {
   Q_D(qMRMLVirtualRealityView);
+  if (!d->Interactor)
+  {
+    return;
+  }
   vtkSlicerVirtualRealityLogic::SetGestureButtonToNone(d->Interactor);
 }
 
@@ -1422,6 +1459,10 @@ void qMRMLVirtualRealityView::setGestureButtonToNone()
 QString qMRMLVirtualRealityView::actionManifestPath() const
 {
   Q_D(const qMRMLVirtualRealityView);
+  if (!d->Interactor)
+  {
+    return QString();
+  }
   return QString::fromStdString(d->Interactor->GetActionManifestDirectory());
 }
 


### PR DESCRIPTION
vtkVirtualRealityComplexGestureRecognizer held a strong vtkSmartPointer back to the vtkVirtualRealityViewOpen{XR,VR}Interactor that owns it (vtkNew member, SetInteractor(this) in the constructor). The resulting cycle kept the interactor alive forever and, through it, the interactor style, style delegate, VR renderer, camera, lights, all actors, pickers and the VR menu, leaking the whole VR scene graph every session (reported by vtkDebugLeaks at exit).

Fixed by using a vtkWeakPointer instead.